### PR TITLE
docs: fix markdown tables

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,8 @@ extensions = [
 #    'sphinx.ext.autosectionlabel',
     'sphinx_scylladb_theme',
     'sphinx_multiversion',
-    'recommonmark'
+    'recommonmark',
+    'sphinx_markdown_tables',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -243,9 +243,8 @@ expected output:
 
 The code package structure is as follows:
 
-+--------------+-------------------------------------+
-|     Name     |               Purpose               |
-+==============+=====================================+
+| Name         | Purpose                             |
+| ------------ | ----------------------------------- |
 | /api         | swagger api spec                    |
 | /cmd         | applications executables            |
 | /cmd/migrate | install database schema             |
@@ -256,7 +255,6 @@ The code package structure is as follows:
 | /db/cql      | database schema                     |
 | /handler     | swagger REST API handlers           |
 | /model       | application models and ORM metadata |
-+--------------+-------------------------------------+
 
 After data is collected from the pets via the sensors on their collars, it is
 delivered to the central database for analysis and for health status checking.

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -14,6 +14,7 @@ sphinx-sitemap = "2.1.0"
 sphinx-autobuild = "0.7.1"
 Sphinx = "2.4.4"
 sphinx-multiversion-scylla = "0.2.4"
+sphinx-markdown-tables = "0.0.15"
 
 [tool.poetry.dev-dependencies]
 pytest = "5.2"


### PR DESCRIPTION
[Recommonmark](https://github.com/readthedocs/recommonmark/issues/103) does not support rendering Markdown tables. This PR adds the extension ``sphinx_markdown_tables`` to display tables as expected without having to rewrite them in RestructuredText.

Example:
![image](https://user-images.githubusercontent.com/9107969/102327897-46baab80-3f7e-11eb-91aa-bb3d8616ae87.png)
