### PR TITLE
Add go-app service to docker compose

### DIFF
--- a/go/docker-compose.yml
+++ b/go/docker-compose.yml
@@ -1,32 +1,50 @@
 version: '3'
 
 services:
-  carepet-scylla1:
-    image: scylladb/scylla
-    container_name: carepet-scylla1
-    command: --smp 1
-    environment:
-      - "SCYLLA_JMX_ADDR=-ja 0.0.0.0"
-      - "SCYLLA_JMX_REMOTE=-r"
-    expose:
-      - "7199"
+    go-app:
+        image: golang:1.14
+        container_name: go-app
+        depends_on:
+            - carepet-scylla1
+        working_dir: /app
+        command: sh -c "
+            git clone https://github.com/scylladb/care-pet /care-pet &&
+            cd /care-pet/go &&
+            go build ./cmd/migrate &&
+            go build ./cmd/sensor &&
+            go build ./cmd/loadtest &&
+            go build ./cmd/server &&
+            cp -a . ../../app &&
+            tail -F anything"
 
-  carepet-scylla2:
-    image: scylladb/scylla
-    container_name: carepet-scylla2
-    command: --smp 1 --seeds=carepet-scylla1
-    environment:
-      - "SCYLLA_JMX_ADDR=-ja 0.0.0.0"
-      - "SCYLLA_JMX_REMOTE=-r"
-    expose:
-      - "7199"
+        expose:
+            - '8000'
+    carepet-scylla1:
+        image: scylladb/scylla
+        container_name: carepet-scylla1
+        command: --smp 1
+        environment:
+            - 'SCYLLA_JMX_ADDR=-ja 0.0.0.0'
+            - 'SCYLLA_JMX_REMOTE=-r'
+        expose:
+            - '7199'
 
-  carepet-scylla3:
-    image: scylladb/scylla
-    container_name: carepet-scylla3
-    command: --smp 1 --seeds=carepet-scylla1
-    environment:
-      - "SCYLLA_JMX_ADDR=-ja 0.0.0.0"
-      - "SCYLLA_JMX_REMOTE=-r"
-    expose:
-      - "7199"
+    carepet-scylla2:
+        image: scylladb/scylla
+        container_name: carepet-scylla2
+        command: --smp 1 --seeds=carepet-scylla1
+        environment:
+            - 'SCYLLA_JMX_ADDR=-ja 0.0.0.0'
+            - 'SCYLLA_JMX_REMOTE=-r'
+        expose:
+            - '7199'
+
+    carepet-scylla3:
+        image: scylladb/scylla
+        container_name: carepet-scylla3
+        command: --smp 1 --seeds=carepet-scylla1
+        environment:
+            - 'SCYLLA_JMX_ADDR=-ja 0.0.0.0'
+            - 'SCYLLA_JMX_REMOTE=-r'
+        expose:
+            - '7199'


### PR DESCRIPTION
Adding the go-app service to the docker-compose.
Note that the docker-compose builds the go project (migrate, sensor and server).
the purpose is to have a base for the developers to connect to the carepet-scylla * nodes.