### PR TITLE
Docs update theme 1.2

### DIFF
--- a/.github/workflows/docs-links.yaml
+++ b/.github/workflows/docs-links.yaml
@@ -1,0 +1,34 @@
+name: "Docs / Links"
+# For more information,
+# see https://sphinx-theme.scylladb.com/stable/deployment/production.html#available-workflows
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # At 00:00 on Sunday
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.3.2
+        with:
+          args: --verbose --no-progress './**/*.md' './**/*.rst'
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Create Issue From File
+        if: ${{ steps.lychee.outputs.exit_code != 0 }}
+        uses: peter-evans/create-issue-from-file@v3
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue

--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -1,5 +1,6 @@
 name: "Docs / Publish"
-# For more information, see https://sphinx-theme.scylladb.com/stable/github-pages.html#available-workflows
+# For more information,
+# see https://sphinx-theme.scylladb.com/stable/deployment/production.html#available-workflows
 
 on:
   push:
@@ -14,16 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v2.3.1
+        uses: actions/setup-python@v3
         with:
           python-version: 3.7
-      - name: Set up Poetry
-        run: curl -sSL https://install.python-poetry.org | python -
+      - name: Set up env
+        run: make -C docs setupenv
       - name: Build docs
         run: make -C docs multiversion
       - name: Deploy docs to GitHub Pages

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -1,5 +1,6 @@
 name: "Docs / Build PR"
-# For more information, see https://sphinx-theme.scylladb.com/stable/github-pages.html#available-workflows
+# For more information,
+# see https://sphinx-theme.scylladb.com/stable/deployment/production.html#available-workflows
 
 on:
   pull_request:
@@ -13,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v2.3.1
+        uses: actions/setup-python@v3
         with:
           python-version: 3.7
-      - name: Set up Poetry
-        run: curl -sSL https://install.python-poetry.org | python -
+      - name: Set up env
+        run: make -C docs setupenv
       - name: Build docs
         run: make -C docs test

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,3 @@
+http://127.0.0.1
+http://127.0.0.1
+http://localhost

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 # You can set these variables from the command line.
 
-POETRY        = $(HOME)/.local/bin/poetry
+POETRY        = poetry
 SPHINXOPTS    = -j auto
 SPHINXBUILD   = $(POETRY) run sphinx-build
 PAPER         =
@@ -18,26 +18,34 @@ TESTSPHINXOPTS  = $(ALLSPHINXOPTS) -W --keep-going
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(SOURCEDIR)
 
+# Windows variables
+ifeq ($(OS),Windows_NT)
+    POETRY = $(APPDATA)\Python\Scripts\poetry
+endif
+
 .PHONY: all
 all: dirhtml
 
-.PHONY: pristine
-pristine: clean
-	git clean -dfX
+# Setup commands
+.PHONY: setupenv
+setupenv:
+	pip install -q poetry
 
 .PHONY: setup
 setup:
 	$(POETRY) install
 	$(POETRY) update
 
+# Clean commands
 .PHONY: clean
 clean:
 	rm -rf $(BUILDDIR)/*
 
-.PHONY: preview
-preview: setup
-	$(POETRY) run sphinx-autobuild -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml --port 5500
+.PHONY: pristine
+pristine: clean
+	git clean -dfX
 
+# Generate output commands
 .PHONY: dirhtml
 dirhtml: setup
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
@@ -49,12 +57,6 @@ singlehtml: setup
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
 	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
-
-.PHONY: test
-test: setup
-	$(SPHINXBUILD) -b dirhtml $(TESTSPHINXOPTS) $(BUILDDIR)/dirhtml
-	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
 .PHONY: epub
 epub: 	setup
@@ -74,16 +76,28 @@ dummy: 	setup
 	@echo
 	@echo "Build finished. Dummy builder generates no files."
 
-.PHONY: linkcheck
-linkcheck: setup
-	$(SPHINXBUILD) -b linkcheck $(SOURCEDIR) $(BUILDDIR)/linkcheck
-
 .PHONY: multiversion
 multiversion: setup
 	$(POETRY) run sphinx-multiversion $(SOURCEDIR) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
+# Preview commands
+.PHONY: preview
+preview: setup
+	$(POETRY) run sphinx-autobuild -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml --port 5500
+
 .PHONY: multiversionpreview
 multiversionpreview: multiversion
 	$(POETRY) run python -m http.server 5500 --directory $(BUILDDIR)/dirhtml
+
+# Test commands
+.PHONY: test
+test: setup
+	$(SPHINXBUILD) -b dirhtml $(TESTSPHINXOPTS) $(BUILDDIR)/dirhtml
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+
+.PHONY: linkcheck
+linkcheck: setup
+	$(SPHINXBUILD) -b linkcheck $(SOURCEDIR) $(BUILDDIR)/linkcheck

--- a/docs/build-with-go.md
+++ b/docs/build-with-go.md
@@ -5,7 +5,7 @@ Build an IoT App with Go
 
 In this section, we will walk you through the CarePet commands and explain the code behind them.
 
-As explained in [Getting Started with CarePet](/getting_started), the project is structured as follows:
+As explained in [Getting Started with CarePet](/getting_started.md), the project is structured as follows:
 - Migrate (/cmd/migrate) - Creates the CarePet keyspace and tables.
 - Collar (/cmd/sensor) - Simulates a pet's collar by generating the pet's health data and pushing the data into the storage.
 - Server (/cmd/server) - REST API service for tracking the pets’ health state.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,16 @@ from sphinx_scylladb_theme.utils import multiversion_regex_builder
 
 # -- General configuration ------------------------------------------------
 
+# Build documentation for the following tags and branches
+TAGS = []
+BRANCHES = ["master"]
+# Set the latest version.
+LATEST_VERSION = "master"
+# Set which versions are not released yet.
+UNSTABLE_VERSIONS = ["master"]
+# Set which versions are deprecated
+DEPRECATED_VERSIONS = [""]
+
 # Add any Sphinx extension module names here, as strings.
 extensions = [
     "sphinx.ext.autodoc",
@@ -56,7 +66,10 @@ html_theme_options = {
     'github_issues_repository': 'scylladb/care-pet',
     'github_repository': 'scylladb/care-pet',
     'hide_edit_this_page_button': 'false',
+    'hide_version_dropdown': UNSTABLE_VERSIONS,
     'site_description': 'ScyllaDB IoT Example Documentation',
+    "versions_unstable": UNSTABLE_VERSIONS,
+    "versions_deprecated": DEPRECATED_VERSIONS,
 }
 
 # If not None, a 'Last updated on:' timestamp is inserted at every page
@@ -102,20 +115,17 @@ redirects_file = "_utils/redirections.yaml"
 
 # -- Options for multiversion --------------------------------------------
 
-# Whitelist pattern for tags (set to None to ignore all tags)
-TAGS = []
+# Whitelist pattern for tags
 smv_tag_whitelist = multiversion_regex_builder(TAGS)
-# Whitelist pattern for branches (set to None to ignore all branches)
-BRANCHES = ['master']
+# Whitelist pattern for branches
 smv_branch_whitelist = multiversion_regex_builder(BRANCHES)
 # Defines which version is considered to be the latest stable version.
-# Must be listed in smv_tag_whitelist or smv_branch_whitelist.
-smv_latest_version = 'master'
-smv_rename_latest_version = ''
+smv_latest_version = LATEST_VERSION
+# Defines the new name for the latest version.
+smv_rename_latest_version = "stable"
 # Whitelist pattern for remotes (set to None to use local branches only)
 smv_remote_whitelist = r"^origin$"
 # Pattern for released versions
-smv_released_pattern = r'^tags/.*$'
+smv_released_pattern = r"^tags/.*$"
 # Format for versioned output directories inside the build directory
-smv_outputdir_format = '{ref.name}'
-
+smv_outputdir_format = "{ref.name}"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,6 @@
 :full-width:
+:hide-sidebar:
+:hide-secondary-sidebar:
 :hide-version-warning:
 :hide-pre-content:
 :hide-post-content:

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -7,13 +7,13 @@ authors = ["ScyllaDB Documentation Contributors"]
 [tool.poetry.dependencies]
 python = "^3.7"
 pyyaml = "^6.0"
-pygments = "2.2.0"
+pygments = "^2.11.2"
 recommonmark = "^0.7.1"
-sphinx-scylladb-theme = "~1.1.0"
+sphinx-scylladb-theme = "~1.2.0"
 sphinx-sitemap = "2.1.0"
 sphinx-autobuild = "^2021.3.14"
 Sphinx = "^4.3.2"
-sphinx-multiversion-scylla = "~0.2.10"
+sphinx-multiversion-scylla = "~0.2.11"
 sphinx-markdown-tables = "0.0.15"
 
 [build-system]


### PR DESCRIPTION
Related issue https://github.com/scylladb/sphinx-scylladb-theme/issues/395

ScyllaDB Sphinx Theme 1.2 is now released 🥳 

We’ve added automatic checks for broken links and introduced numerous UI updates.

You can read more about all notable changes [here](https://sphinx-theme.scylladb.com/stable/upgrade/CHANGELOG.html#march-2022).


## How to test this PR

1. Clone this PR. For more information, see [Cloning pull requests locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally).

2. Enter the docs folder, and run:

```
make preview
````

4. Open http://127.0.0.1:5500/ with your favorite browser. The doc should render without errors, and the version should be Sphinx Theme version (see the footer) must be ``1.2.x``:

![image](https://user-images.githubusercontent.com/9107969/159508628-9da8fb3f-b1fa-45e2-a99e-d5f44a90bfaf.png)