### PR TITLE
docs: enable pull request previews

### DIFF
--- a/.amplify.yml
+++ b/.amplify.yml
@@ -1,0 +1,20 @@
+version: 1
+applications:
+  - frontend:
+      phases:
+        preBuild:
+          commands:
+            - ln -fs /usr/local/bin/pip3.8 /usr/bin/pip
+            - ln -fs /usr/local/bin/python3.8 /usr/bin/python
+            - pip install --user pipenv
+        build:
+          commands:
+            - make setupenv
+            - make dirhtml
+      artifacts:
+        baseDirectory: _build/dirhtml
+        files:
+          - '**/*'
+      cache:
+        paths: []
+    appRoot: docs


### PR DESCRIPTION
We are adding AWS Amplify in some selected projects to build a preview site for the docs every time someone sends a pull request that updates the docs folder.

Once the build completes, the pull request receives a message with a link to preview the docs.

![image](https://user-images.githubusercontent.com/9107969/162934472-bfb40942-e39d-4ad3-8b65-6925d31e0e7e.png)


This pull request adds the file that defines how to build docs every time there is a new pull request.

Once this PR is merged, @tzach should follow [Enable Previews](https://github.com/scylladb/sphinx-scylladb-theme/blob/8316b705d909b695aa2765a5826a53be20e020e9/docs/source/deployment/previews.rst#enable-previews) guide to let AWS know you want to enable build pull request previews for this repository.