### PR TITLE
docs: only check broken links in docs folder

### DIFF
--- a/.github/workflows/docs-links.yaml
+++ b/.github/workflows/docs-links.yaml
@@ -21,7 +21,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.3.2
         with:
-          args: --verbose --no-progress './**/*.md' './**/*.rst'
+          args: --verbose --exclude-mail --no-progress './docs/**/*.md' './docs/**/*.rst'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 


### PR DESCRIPTION
Closes https://github.com/scylladb/care-pet/issues/81

Closes https://github.com/scylladb/care-pet/issues/79

Closes https://github.com/scylladb/care-pet/issues/74

Closes https://github.com/scylladb/care-pet/issues/73

Only check for broken links within the docs folder and exclude email addresses.