### PR TITLE
docs: Update Markdown tables extension

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -14,7 +14,7 @@ sphinx-sitemap = "2.2.0"
 sphinx-autobuild = "2021.3.14"
 Sphinx = "4.3.2"
 sphinx-multiversion-scylla = "~0.2.11"
-sphinx-markdown-tables = "0.0.15"
+sphinx-markdown-tables = "0.0.17"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Fixes the build error raised on https://github.com/scylladb/care-pet/pull/101

Updates the sphinx-markdown-tables extension to the latest version to remove the warning:

> WARNING]: Extension error (sphinx_markdown_tables):
                                    Handler <function process_tables at 0x7fcd2362f670> for event 'source-read' threw an exception (exception: __init__() missing 1 required positional argument: 'config')
