### PR TITLE
docs: update theme 1.3

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -27,6 +27,8 @@ jobs:
         run: make -C docs setupenv
       - name: Build docs
         run: make -C docs multiversion
+      - name: Build redirects
+        run: make -C docs redirects
       - name: Deploy docs to GitHub Pages
         run: ./docs/_utils/deploy.sh
         env:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -82,6 +82,12 @@ multiversion: setup
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
+.PHONY: redirects
+redirects: setup
+	$(POETRY) run redirects-cli fromfile --yaml-file _utils/redirects.yaml --output-dir $(BUILDDIR)/dirhtml
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+
 # Preview commands
 .PHONY: preview
 preview: setup

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,9 +13,9 @@ BRANCHES = ["master"]
 # Set the latest version.
 LATEST_VERSION = "master"
 # Set which versions are not released yet.
-UNSTABLE_VERSIONS = ["master"]
+UNSTABLE_VERSIONS = []
 # Set which versions are deprecated
-DEPRECATED_VERSIONS = [""]
+DEPRECATED_VERSIONS = []
 
 # Add any Sphinx extension module names here, as strings.
 extensions = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,11 +109,6 @@ notfound_template = "404.html"
 # Prefix added to all the URLs generated in the 404 page.
 notfound_urls_prefix = ""
 
-# -- Options for redirect extension ---------------------------------------
-
-# Read a YAML dictionary of redirections and generate an HTML file for each
-redirects_file = "_utils/redirections.yaml"
-
 # -- Options for sitemap extension ---------------------------------------
 
 sitemap_url_scheme = "stable/{link}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ BRANCHES = ["master"]
 # Set the latest version.
 LATEST_VERSION = "master"
 # Set which versions are not released yet.
-UNSTABLE_VERSIONS = []
+UNSTABLE_VERSIONS = ["master"]
 # Set which versions are deprecated
 DEPRECATED_VERSIONS = []
 
@@ -67,7 +67,6 @@ html_theme_options = {
     'github_issues_repository': 'scylladb/care-pet',
     'github_repository': 'scylladb/care-pet',
     'hide_edit_this_page_button': 'false',
-    'hide_version_dropdown': UNSTABLE_VERSIONS,
     'site_description': 'ScyllaDB IoT Example Documentation',
     "versions_unstable": UNSTABLE_VERSIONS,
     "versions_deprecated": DEPRECATED_VERSIONS,

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -15,7 +15,7 @@ sphinx-autobuild = "2021.3.14"
 Sphinx = "4.3.2"
 sphinx-multiversion-scylla = "~0.2.11"
 sphinx-markdown-tables = "0.0.17"
-redirects_cli ="^0.1.2"
+redirects_cli ="~0.1.2"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -9,12 +9,12 @@ python = "^3.7"
 pyyaml = "6.0"
 pygments = "2.11.2"
 recommonmark = "0.7.1"
-sphinx-scylladb-theme = "~1.2.1"
+sphinx-scylladb-theme = "~1.3.0"
 sphinx-sitemap = "2.2.0"
 sphinx-autobuild = "2021.3.14"
 Sphinx = "4.3.2"
 sphinx-multiversion-scylla = "~0.2.11"
-sphinx-markdown-tables = "0.0.15"
+sphinx-markdown-tables = "0.0.17"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -9,13 +9,13 @@ python = "^3.7"
 pyyaml = "6.0"
 pygments = "2.11.2"
 recommonmark = "0.7.1"
+redirects_cli ="~0.1.2"
 sphinx-scylladb-theme = "~1.3.1"
 sphinx-sitemap = "2.2.0"
 sphinx-autobuild = "2021.3.14"
 Sphinx = "4.3.2"
 sphinx-multiversion-scylla = "~0.2.11"
 sphinx-markdown-tables = "0.0.17"
-redirects_cli ="~0.1.2"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -9,12 +9,13 @@ python = "^3.7"
 pyyaml = "6.0"
 pygments = "2.11.2"
 recommonmark = "0.7.1"
-sphinx-scylladb-theme = "~1.3.0"
+sphinx-scylladb-theme = "~1.3.1"
 sphinx-sitemap = "2.2.0"
 sphinx-autobuild = "2021.3.14"
 Sphinx = "4.3.2"
 sphinx-multiversion-scylla = "~0.2.11"
 sphinx-markdown-tables = "0.0.17"
+redirects_cli ="^0.1.2"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Related issue https://github.com/scylladb/sphinx-scylladb-theme/issues/548

ScyllaDB Sphinx Theme 1.3 is now released 🥳 

We’ve added better redirects support and introduced numerous UI updates.

You can read more about all notable changes [here](https://sphinx-theme.scylladb.com/stable/upgrade/CHANGELOG.html#aug-2022).


## How to test this PR

1. Clone this PR. For more information, see [Cloning pull requests locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally).

2. Enter the docs folder, and run:

```
make preview
````

4. Open  http://localhost:5500 with your favorite browser. The doc should render without errors, and the version should be Sphinx Theme version (see the footer) must be ``1.3.x``:

![image](https://user-images.githubusercontent.com/9107969/185590281-c79c5278-36d1-4bca-8197-e94824be1759.png)
