### PR TITLE
Updating care pet new link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and consists of 3 parts:
 - a web app for reading and analyzing the pets' data
 - a database migration tool
 
-Read the [Documentation for the Care-Pet Example](https://iot.scylladb.com/stable/)
+Read the [Documentation for the Care-Pet Example](https://iot.scylladb.com)
 
 Quick Start
 ---

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and consists of 3 parts:
 - a web app for reading and analyzing the pets' data
 - a database migration tool
 
-Read the [Documentation for the Care-Pet Example](https://iot.docs.scylladb.com/)
+Read the [Documentation for the Care-Pet Example](https://iot.scylladb.com/stable/)
 
 Quick Start
 ---


### PR DESCRIPTION
There's an outdated link that was supposed to point to Care Pet docs.

Probably it broke when the new docs arrived.