### PR TITLE
docs: update theme 1.6

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 # You can set these variables from the command line.
 
 POETRY        = poetry
-SPHINXOPTS    = 
+SPHINXOPTS    = -j auto
 SPHINXBUILD   = $(POETRY) run sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,11 +18,6 @@ TESTSPHINXOPTS  = $(ALLSPHINXOPTS) -W --keep-going
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(SOURCEDIR)
 
-# Windows variables
-ifeq ($(OS),Windows_NT)
-    POETRY = $(APPDATA)\Python\Scripts\poetry
-endif
-
 .PHONY: all
 all: dirhtml
 

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -5,16 +5,16 @@ version = "1.0"
 authors = ["ScyllaDB Documentation Contributors"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
-pyyaml = "6.0"
+python = "^3.9"
+pyyaml = "6.0.1"
 pygments = "2.15.1"
 recommonmark = "0.7.1"
 redirects_cli ="~0.1.2"
-sphinx-scylladb-theme = "~1.5.1"
-sphinx-sitemap = "2.5.0"
+sphinx-scylladb-theme = "~1.6.1"
+sphinx-sitemap = "2.5.1"
 sphinx-autobuild = "2021.3.14"
-Sphinx = "4.3.2"
-sphinx-multiversion-scylla = "~0.2.11"
+Sphinx = "7.2.6"
+sphinx-multiversion-scylla = "~0.3.1"
 sphinx-markdown-tables = "0.0.17"
 
 [build-system]


### PR DESCRIPTION
Related issue https://github.com/scylladb/sphinx-scylladb-theme/issues/914

ScyllaDB Sphinx Theme 1.6 is out 🥳 We've introduced parallel builds for faster performance and added support for Git LFS. Now requiring Python 3.9 due to an upgrade to Sphinx 7.2.4. Note for Windows users: support for Git Bash is discontinued, switch to WSL is advised.

You can read more about all notable changes [here](https://sphinx-theme.scylladb.com/master/upgrade/CHANGELOG.html#oct-2023).

## How to test this PR

1. Clone this PR. For more information, see [Cloning pull requests locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally).

2. Enter the docs folder, and run:
  
    ```
    make preview
    ````

3. Open http://localhost:5500 with your favorite browser. The doc should render without errors, and the version should be Sphinx Theme version (see the footer) must be ``1.6.x``:

![image](https://github.com/scylladb/care-pet/assets/9107969/98b9b0c3-d3c5-4241-877e-a3af73226972)