### PR TITLE
fix: default datacenter

### DIFF
--- a/javascript/src/config.js
+++ b/javascript/src/config.js
@@ -16,7 +16,7 @@ function dbConfig(name) {
             '-p, --password <password>',
             'Password based authentication password'
         )
-        .option('-d, --datacenter <datacenter>', 'Local data center');
+        .option('-d, --datacenter <datacenter>', 'Local data center', 'datacenter1');
 }
 
 module.exports = dbConfig;


### PR DESCRIPTION
Since  we're running mostly in a docker node ring, seems more reasonable to set the default datacenter as "datacenter1" (default scylla configuration).

Solves #118 