### PR TITLE
Fix and refactor Java example

### DIFF
--- a/docs/build-with-java.md
+++ b/docs/build-with-java.md
@@ -229,7 +229,7 @@ $ ./bin/server.sh --hosts $NODE1 --datacenter datacenter1
 
 In the care-pet example, run:
 
-  `$ curl http://127.0.0.1:8000/api/owner/{id}`.
+  `$ curl http://127.0.0.1:8080/api/owner/{id}`.
   
   You can expect the following response:
 

--- a/java/README.md
+++ b/java/README.md
@@ -17,7 +17,7 @@ Quick Start
 
 Prerequisites:
 
-- [JDK](https://openjdk.java.net/install/) at least OpenJDK 8
+- [JDK](https://openjdk.java.net/install/) at least OpenJDK 11
 - [maven](http://maven.apache.org/)
 - [docker](https://www.docker.com/)
 - [docker-compose](https://docs.docker.com/compose/)
@@ -59,21 +59,13 @@ To initialize database execute:
 
 Expected output:
 
-    SLF4J: Class path contains multiple SLF4J bindings.
-    SLF4J: Found binding in [jar:file:/home/sitano/.m2/repository/org/slf4j/slf4j-simple/1.7.26/slf4j-simple-1.7.26.jar!/org/slf4j/impl/StaticLoggerBinder.class]
-    SLF4J: Found binding in [jar:file:/home/sitano/.m2/repository/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
-    SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
-    SLF4J: Actual binding is of type [org.slf4j.impl.SimpleLoggerFactory]
     [main] INFO com.carepet.Migrate - creating keyspace...
-    Using Scylla optimized driver!!!
     [main] INFO com.datastax.oss.driver.api.core.session.SessionBuilder - Using Scylla optimized driver!!!
-    [main] INFO com.datastax.oss.driver.internal.core.DefaultMavenCoordinates - DataStax Java driver for Apache Cassandra(R) (com.scylladb:java-driver-core) version 4.8.0-scylla-0
+    [main] INFO com.datastax.oss.driver.internal.core.DefaultMavenCoordinates - ScyllaDB Java Driver (com.scylladb:java-driver-core) version 4.19.0.1
     [s0-admin-0] INFO com.datastax.oss.driver.internal.core.time.Clock - Using native clock for microsecond precision
     [main] INFO com.carepet.Migrate - creating table...
-    Using Scylla optimized driver!!!
     [main] INFO com.datastax.oss.driver.api.core.session.SessionBuilder - Using Scylla optimized driver!!!
     [s1-admin-0] INFO com.datastax.oss.driver.internal.core.time.Clock - Using native clock for microsecond precision
-    Using Scylla optimized driver!!!
     [main] INFO com.datastax.oss.driver.api.core.session.SessionBuilder - Using Scylla optimized driver!!!
     [s2-admin-0] INFO com.datastax.oss.driver.internal.core.time.Clock - Using native clock for microsecond precision
     Keyspace: carepet; Table: measurement
@@ -92,7 +84,7 @@ You can check the database structure with:
     cqlsh> USE carepet;
     cqlsh:carepet> DESCRIBE TABLES
 
-    pet  sensor_avg  gocqlx_migrate  measurement  owner  sensor
+    pet  sensor_avg  measurement  owner  sensor
 
     cqlsh:carepet> DESCRIBE TABLE pet
 
@@ -135,32 +127,25 @@ To start pet collar simulation execute the following in the separate terminal:
 
 Expected output:
 
-    SLF4J: Class path contains multiple SLF4J bindings.
-    SLF4J: Found binding in [jar:file:/home/sitano/.m2/repository/org/slf4j/slf4j-simple/1.7.26/slf4j-simple-1.7.26.jar!/org/slf4j/impl/StaticLoggerBinder.class]
-    SLF4J: Found binding in [jar:file:/home/sitano/.m2/repository/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
-    SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
-    SLF4J: Actual binding is of type [org.slf4j.impl.SimpleLoggerFactory]
-    Using Scylla optimized driver!!!
     [main] INFO com.datastax.oss.driver.api.core.session.SessionBuilder - Using Scylla optimized driver!!!
-    [main] INFO com.datastax.oss.driver.internal.core.DefaultMavenCoordinates - DataStax Java driver for Apache Cassandra(R) (com.scylladb:java-driver-core) version 4.8.0-scylla-0
+    [main] INFO com.datastax.oss.driver.internal.core.DefaultMavenCoordinates - ScyllaDB Java Driver (com.scylladb:java-driver-core) version 4.19.0.1
     [s0-admin-0] INFO com.datastax.oss.driver.internal.core.time.Clock - Using native clock for microsecond precision
-    [main] INFO com.carepet.Migrate - owner = Owner{ownerId=0701da30-52f0-4ee4-911c-f9ac951bf3b1, name='OBahu5A3', address='5UtxnIxqfa'}
-    [main] INFO com.carepet.Migrate - pet = Pet{ownerId=0701da30-52f0-4ee4-911c-f9ac951bf3b1, petId=765ac83f-9744-450b-a4ec-9d40359edeae, chipId='', species='', breed='', color='', gender='', age=55, weight=7.937521, address='home', name='0YaLHRJq'}
-    [main] INFO com.carepet.Migrate - sensor = Sensor{petId=765ac83f-9744-450b-a4ec-9d40359edeae, sensorId=25ce6029-20a2-4532-a154-d82ea8da800d, type='R'}
-    [main] INFO com.carepet.Migrate - sensor = Sensor{petId=765ac83f-9744-450b-a4ec-9d40359edeae, sensorId=14a94142-12e8-414f-861e-15571d087c41, type='P'}
-    [main] INFO com.carepet.Migrate - sensor = Sensor{petId=765ac83f-9744-450b-a4ec-9d40359edeae, sensorId=630b2f96-bd0c-43c1-93a7-7750229f6da8, type='R'}
-    [main] INFO com.carepet.Migrate - sensor = Sensor{petId=765ac83f-9744-450b-a4ec-9d40359edeae, sensorId=06ffd4ba-21e6-4973-bda9-e0346c48334c, type='R'}
-    Using Scylla optimized driver!!!
+    [main] INFO com.carepet.Sensor - owner = Owner{ownerId=0701da30-52f0-4ee4-911c-f9ac951bf3b1, name='OBahu5A3', address='5UtxnIxqfa'}
+    [main] INFO com.carepet.Sensor - pet = Pet{ownerId=0701da30-52f0-4ee4-911c-f9ac951bf3b1, petId=765ac83f-9744-450b-a4ec-9d40359edeae, chipId='', species='', breed='', color='', gender='', age=55, weight=7.937521, address='home', name='0YaLHRJq'}
+    [main] INFO com.carepet.Sensor - sensor = Sensor{petId=765ac83f-9744-450b-a4ec-9d40359edeae, sensorId=25ce6029-20a2-4532-a154-d82ea8da800d, type='R'}
+    [main] INFO com.carepet.Sensor - sensor = Sensor{petId=765ac83f-9744-450b-a4ec-9d40359edeae, sensorId=14a94142-12e8-414f-861e-15571d087c41, type='P'}
+    [main] INFO com.carepet.Sensor - sensor = Sensor{petId=765ac83f-9744-450b-a4ec-9d40359edeae, sensorId=630b2f96-bd0c-43c1-93a7-7750229f6da8, type='R'}
+    [main] INFO com.carepet.Sensor - sensor = Sensor{petId=765ac83f-9744-450b-a4ec-9d40359edeae, sensorId=06ffd4ba-21e6-4973-bda9-e0346c48334c, type='R'}
     [main] INFO com.datastax.oss.driver.api.core.session.SessionBuilder - Using Scylla optimized driver!!!
     [s1-admin-0] INFO com.datastax.oss.driver.internal.core.time.Clock - Using native clock for microsecond precision
-    [main] INFO com.carepet.Migrate - Measure{sensorId=25ce6029-20a2-4532-a154-d82ea8da800d, ts=2020-09-11T12:47:26.807Z, value=34.0}
-    [main] INFO com.carepet.Migrate - Measure{sensorId=14a94142-12e8-414f-861e-15571d087c41, ts=2020-09-11T12:47:26.809Z, value=84.0}
-    [main] INFO com.carepet.Migrate - Measure{sensorId=630b2f96-bd0c-43c1-93a7-7750229f6da8, ts=2020-09-11T12:47:26.809Z, value=35.0}
-    [main] INFO com.carepet.Migrate - Measure{sensorId=06ffd4ba-21e6-4973-bda9-e0346c48334c, ts=2020-09-11T12:47:26.809Z, value=37.0}
-    [main] INFO com.carepet.Migrate - pushing data
+    [main] INFO com.carepet.Sensor - Measure{sensorId=25ce6029-20a2-4532-a154-d82ea8da800d, ts=2020-09-11T12:47:26.807Z, value=34.0}
+    [main] INFO com.carepet.Sensor - Measure{sensorId=14a94142-12e8-414f-861e-15571d087c41, ts=2020-09-11T12:47:26.809Z, value=84.0}
+    [main] INFO com.carepet.Sensor - Measure{sensorId=630b2f96-bd0c-43c1-93a7-7750229f6da8, ts=2020-09-11T12:47:26.809Z, value=35.0}
+    [main] INFO com.carepet.Sensor - Measure{sensorId=06ffd4ba-21e6-4973-bda9-e0346c48334c, ts=2020-09-11T12:47:26.809Z, value=37.0}
+    [main] INFO com.carepet.Sensor - pushing data
     ...
 
-Write down the pet Owner ID (ID is something after the `#` sign without trailing spaces).
+Write down the pet Owner ID (e.g. `0701da30-52f0-4ee4-911c-f9ac951bf3b1` from the log line `owner = Owner{ownerId=...}`).
 To start REST API service execute the following in the separate terminal:
 
     $ mvn package
@@ -169,14 +154,8 @@ To start REST API service execute the following in the separate terminal:
 
 Expected output:
 
-    SLF4J: Class path contains multiple SLF4J bindings.
-    SLF4J: Found binding in [jar:file:/home/sitano/.m2/repository/org/slf4j/slf4j-simple/1.7.26/slf4j-simple-1.7.26.jar!/org/slf4j/impl/StaticLoggerBinder.class]
-    SLF4J: Found binding in [jar:file:/home/sitano/.m2/repository/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
-    SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
-    SLF4J: Actual binding is of type [org.slf4j.impl.SimpleLoggerFactory]
-    Using Scylla optimized driver!!!
     [main] INFO com.datastax.oss.driver.api.core.session.SessionBuilder - Using Scylla optimized driver!!!
-    [main] INFO com.datastax.oss.driver.internal.core.DefaultMavenCoordinates - DataStax Java driver for Apache Cassandra(R) (com.scylladb:java-driver-core) version 4.8.0-scylla-0
+    [main] INFO com.datastax.oss.driver.internal.core.DefaultMavenCoordinates - ScyllaDB Java Driver (com.scylladb:java-driver-core) version 4.19.0.1
     [s0-admin-0] INFO com.datastax.oss.driver.internal.core.time.Clock - Using native clock for microsecond precision
     [main] INFO io.micronaut.runtime.Micronaut - Startup completed in 684ms. Server Running: http://localhost:8080
 
@@ -326,7 +305,7 @@ Architecture
 How to start a new project with Java
 ---
 
-Install JDK >= 8 and Maven. Create a repository. Clone it. Execute inside of
+Install JDK >= 11 and Maven. Create a repository. Clone it. Execute inside of
 your repository:
 
     $ mvn archetype:generate -DgroupId=com.mycompany.app -DartifactId=my-app -DarchetypeArtifactId=maven-archetype-quickstart -DarchetypeVersion=1.4 -DinteractiveMode=false
@@ -337,7 +316,7 @@ Now when you have your pom module add ScyllaDB driver as a dependency with:
         <dependency>
           <groupId>com.scylladb</groupId>
           <artifactId>java-driver-core</artifactId>
-          <version>4.8.0-scylla-0</version>
+          <version>4.19.0.1</version>
         </dependency>
     </dependencies>
 
@@ -359,15 +338,15 @@ Now your `pom.xml` will be looking something like this:
 
       <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
       </properties>
 
       <dependencies>
           <dependency>
             <groupId>com.scylladb</groupId>
             <artifactId>java-driver-core</artifactId>
-            <version>4.8.0-scylla-0</version>
+            <version>4.19.0.1</version>
           </dependency>
           ...
       </dependencies>
@@ -461,7 +440,7 @@ You can use query builder with the help of:
     <dependency>
       <groupId>com.scylladb</groupId>
       <artifactId>java-driver-query-builder</artifactId>
-      <version>4.8.0-scylla-0</version>
+      <version>4.19.0.1</version>
     </dependency>
 
 To get:
@@ -479,7 +458,7 @@ To use object-data mapping (ORM) include:
     <dependency>
       <groupId>com.scylladb</groupId>
       <artifactId>java-driver-mapper-runtime</artifactId>
-      <version>4.8.0-scylla-0</version>
+      <version>4.19.0.1</version>
     </dependency>
     
 Add annotation processing:
@@ -494,7 +473,7 @@ Add annotation processing:
               <path>
                 <groupId>com.scylladb</groupId>
                 <artifactId>java-driver-mapper-processor</artifactId>
-                <version>4.8.0-scylla-0</version>
+                <version>4.19.0.1</version>
               </path>
             </annotationProcessorPaths>
             <compilerArgs>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -14,17 +14,9 @@
     <micronaut.version>1.2.0</micronaut.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
   </properties>
-
-  <repositories>
-    <!-- io.micronaut -->
-    <repository>
-      <id>jcenter.bintray.com</id>
-      <url>https://jcenter.bintray.com</url>
-    </repository>
-  </repositories>
 
   <dependencyManagement>
     <dependencies>
@@ -42,18 +34,17 @@
     <dependency>
       <groupId>com.scylladb</groupId>
       <artifactId>java-driver-core</artifactId>
-      <version>4.8.0-scylla-0</version>
+      <version>4.19.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.scylladb</groupId>
       <artifactId>java-driver-mapper-runtime</artifactId>
-      <version>4.8.0-scylla-0</version>
+      <version>4.19.0.1</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>1.7.26</version>
-      <scope>runtime</scope>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.17.0</version>
     </dependency>
     <!-- CLI flags -->
     <dependency>
@@ -147,7 +138,7 @@
             <path>
               <groupId>com.scylladb</groupId>
               <artifactId>java-driver-mapper-processor</artifactId>
-              <version>4.8.0-scylla-0</version>
+              <version>4.19.0.1</version>
             </path>
             <path>
               <groupId>io.micronaut</groupId>

--- a/java/src/main/java/com/carepet/Migrate.java
+++ b/java/src/main/java/com/carepet/Migrate.java
@@ -1,7 +1,6 @@
 package com.carepet;
 
 import com.datastax.oss.driver.api.core.CqlSession;
-import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,7 +53,9 @@ public class Migrate {
         LOG.info("creating table...");
         try (CqlSession session = keyspace()) {
             for (String cql : Config.getResource("care-pet-ddl.cql").split(";")) {
-                session.execute(cql);
+                if (!cql.isBlank()) {
+                    session.execute(cql);
+                }
             }
         }
     }
@@ -64,10 +65,11 @@ public class Migrate {
      */
     public void printMetadata() {
         try (CqlSession session = keyspace()) {
-            KeyspaceMetadata keyspace = session.getMetadata().getKeyspace(Config.keyspace).get();
-            for (TableMetadata table : keyspace.getTables().values()) {
-                System.out.printf("Keyspace: %s; Table: %s%n", keyspace.getName(), table.getName());
-            }
+            session.getMetadata().getKeyspace(Config.keyspace).ifPresent(keyspace -> {
+                for (TableMetadata table : keyspace.getTables().values()) {
+                    System.out.printf("Keyspace: %s; Table: %s%n", keyspace.getName(), table.getName());
+                }
+            });
         }
     }
 }

--- a/java/src/main/java/com/carepet/Sensor.java
+++ b/java/src/main/java/com/carepet/Sensor.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Sensor {
-    private static final Logger LOG = LoggerFactory.getLogger(Migrate.class);
+    private static final Logger LOG = LoggerFactory.getLogger(Sensor.class);
     private final SensorConfig config;
     private final Owner owner;
     private final Pet pet;

--- a/java/src/main/java/com/carepet/model/Owner.java
+++ b/java/src/main/java/com/carepet/model/Owner.java
@@ -4,7 +4,7 @@ import com.datastax.oss.driver.api.mapper.annotations.CqlName;
 import com.datastax.oss.driver.api.mapper.annotations.Entity;
 import com.datastax.oss.driver.api.mapper.annotations.PartitionKey;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import java.util.UUID;
 

--- a/java/src/main/java/com/carepet/model/Pet.java
+++ b/java/src/main/java/com/carepet/model/Pet.java
@@ -5,10 +5,10 @@ import com.datastax.oss.driver.api.mapper.annotations.CqlName;
 import com.datastax.oss.driver.api.mapper.annotations.Entity;
 import com.datastax.oss.driver.api.mapper.annotations.PartitionKey;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.lang.RandomStringUtils;
-import org.apache.commons.lang.math.RandomUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 @Entity
 @CqlName("pet")
@@ -62,8 +62,8 @@ public class Pet {
                 ownerId,
                 UUID.randomUUID(),
                 "", "", "", "", "",
-                1 + RandomUtils.nextInt(100),
-                5.0f + 10.0f * RandomUtils.nextFloat(),
+                1 + ThreadLocalRandom.current().nextInt(100),
+                5.0f + 10.0f * ThreadLocalRandom.current().nextFloat(),
                 "home",
                 RandomStringUtils.randomAlphanumeric(8));
     }

--- a/java/src/main/java/com/carepet/model/Sensor.java
+++ b/java/src/main/java/com/carepet/model/Sensor.java
@@ -5,9 +5,9 @@ import com.datastax.oss.driver.api.mapper.annotations.CqlName;
 import com.datastax.oss.driver.api.mapper.annotations.Entity;
 import com.datastax.oss.driver.api.mapper.annotations.PartitionKey;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.lang.math.RandomUtils;
 
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 @Entity
 @CqlName("sensor")
@@ -35,7 +35,7 @@ public class Sensor {
         return new Sensor(
                 petId,
                 UUID.randomUUID(),
-                SensorType.values()[RandomUtils.nextInt(SensorType.values().length)].getType());
+                SensorType.values()[ThreadLocalRandom.current().nextInt(SensorType.values().length)].getType());
     }
 
     public UUID getPetId() {
@@ -66,16 +66,16 @@ public class Sensor {
         switch (SensorType.fromString(type)) {
             case Temperature:
                 // average F
-                return 101.0f + RandomUtils.nextInt(10) - 4;
+                return 101.0f + ThreadLocalRandom.current().nextInt(10) - 4;
             case Pulse:
                 // average beat per minute
-                return 100.0f + RandomUtils.nextInt(40) - 20;
+                return 100.0f + ThreadLocalRandom.current().nextInt(40) - 20;
             case Respiration:
                 // average inhales per minute
-                return 35.0f + RandomUtils.nextInt(5) - 2;
+                return 35.0f + ThreadLocalRandom.current().nextInt(5) - 2;
             case Location:
                 // pet can teleport
-                return 10 * RandomUtils.nextFloat();
+                return 10 * ThreadLocalRandom.current().nextFloat();
             default:
                 return 0.0f;
         }


### PR DESCRIPTION
## Summary

This PR fixes several issues in the Java care-pet example that prevented it from building and running correctly against modern ScyllaDB clusters.

### Issues Fixed

**Code fixes:**
- Upgraded ScyllaDB Java driver from `4.8.0-scylla-0` to `4.19.0.1` (fixes `vector<float,N>` type parsing error on ScyllaDB Cloud and crash in `printMetadata`)
- Fixed `printMetadata` crash: replaced `Optional.get()` with `Optional.ifPresent()`
- Fixed Sensor logger: was incorrectly using `Migrate.class`, corrected to `Sensor.class`
- Removed defunct JCenter repository (shut down Feb 2022)
- Removed duplicate SLF4J binding (removed `slf4j-simple`, kept `logback-classic`)
- Updated Java compiler target from `1.8` to `11`
- Added `commons-lang3` explicitly (no longer transitive); replaced deprecated `RandomUtils` with `ThreadLocalRandom`
- Improved `createSchema` to skip blank CQL strings from trailing semicolons

**README fixes:**
- Updated JDK prerequisite to OpenJDK 11
- Removed stale SLF4J duplicate-binding warnings from expected output
- Fixed sensor expected output class name (`Migrate` → `Sensor`)
- Updated driver version strings, fixed owner ID hint, removed Go-specific table from Java output

**Tutorial fix (`docs/build-with-java.md`):**
- Fixed server port: `8000` → `8080` (Micronaut default)