### PR TITLE
Fix and refactor Python example

### DIFF
--- a/docs/build-with-python.md
+++ b/docs/build-with-python.md
@@ -28,9 +28,9 @@ pip install -r requirements.txt
 ```
 
 ## Start Docker containers (skip this if you use Scylla Cloud)
-Spin up a local ScyllaDB cluster with three nodes using `docker` and `docker-compose`:
+Spin up a local ScyllaDB cluster with three nodes using `docker` and `docker compose`:
 ```bash
-docker-compose up -d
+docker compose up -d
 
 Creating carepet-scylla3 ... done
 Creating carepet-scylla2 ... done
@@ -63,6 +63,9 @@ docker inspect carepet-scylla1
 ```
 
 ## Connect to ScyllaDB and create the database schema
+
+### Local Docker cluster
+
 To connect to your ScyllaDB storage within the container, you need to know the
 IP address of one of the running nodes.
 This is how you can get the IP address of the first node running in the container:
@@ -79,6 +82,19 @@ NODE1=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{en
 Now you can run the migration script that creates the required keyspace and tables:
 ```bash
 python src/migrate.py -h $NODE1
+
+Creating keyspace...
+Done.
+Migrating database...
+Done.
+```
+
+### ScyllaDB Cloud
+
+When using ScyllaDB Cloud, pass your cluster's contact point, username, password,
+and data center name using the `-u`, `-p`, and `-d` flags:
+```bash
+python src/migrate.py -h <node-address> -u <username> -p <password> -d <datacenter>
 
 Creating keyspace...
 Done.
@@ -137,6 +153,8 @@ At this point you have ScyllaDB running with the correct keyspace and tables.
 Start ingesting IoT data (it's suggested to do this in a new separate terminal
 because this process runs indefinitely). Make sure you're still in the virtual
 environment:
+
+**Local Docker cluster:**
 ```bash
 source env/bin/activate
 NODE1=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' carepet-scylla1)
@@ -151,18 +169,22 @@ sensor # b6155934-bd4e-47de-8649-1fad447aa036 type T, new measure: 100.551184314
 sensor # d2c62c4d-9621-469d-b62c-41ef2271fca7 type L, new measure: 37.486651732296835, ts: 2023-01-08 17:36:17.126516
 ```
 
+**ScyllaDB Cloud:**
+```bash
+source env/bin/activate
+python src/sensor.py -h <node-address> -u <username> -p <password> -d <datacenter> --measure 2 --buffer-interval 10
+```
+
 This command starts a script that generates and ingests random IoT data coming
 from two sensors every other second and inserts the data in batches
 every ten seconds. Whenever you see `Pushing data` in the command line that is
-when data actually gets insterted into ScyllaDB.
+when data actually gets inserted into ScyllaDB.
 
 Optional: You can modify the frequency of the generated data by changing the
 `--measure` and `--buffer-interval` arguments. For example,
 you can generate new data points every three seconds and insert the batches
 every 30 seconds:
 ```bash
-source env/bin/activate
-NODE1=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' carepet-scylla1)
 python src/sensor.py -h $NODE1 --measure 3 --buffer-interval 30
 ```
 
@@ -170,6 +192,8 @@ You can run multiple ingestion processes in parallel if you wish.
 
 ## Set up and test REST API
 In a new terminal, start running the API server (make sure that `port 8000` is free):
+
+**Local Docker cluster:**
 ```bash
 source env/bin/activate
 NODE1=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' carepet-scylla1)
@@ -178,7 +202,13 @@ python src/api.py -h $NODE1
 INFO:     Started server process [696274]
 INFO:     Waiting for application startup.
 INFO:     Application startup complete.
-INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
+```
+
+**ScyllaDB Cloud:**
+```bash
+source env/bin/activate
+python src/api.py -h <node-address> -u <username> -p <password> -d <datacenter>
 ```
 
 The API server is running on `http://127.0.0.1:8000`. Test with your
@@ -204,8 +234,6 @@ To test these endpoints, you need to provide either an `owner_id` or a `pet_id`
 as URL path parameter. You can get these values by copying them from the
 beginning of output of the ingestion script:
 ```bash
-source env/bin/activate
-NODE1=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' carepet-scylla1)
 python src/sensor.py -h $NODE1 --measure 1 --buffer-interval 6
 
 Welcome to the Pet collar simulator

--- a/python/README.md
+++ b/python/README.md
@@ -15,10 +15,11 @@ The application has three modules:
 ## Get started
 
 ### Prerequisites:
-* [Python 3.7+](https://www.python.org/downloads/)
+* [Python 3.8+](https://www.python.org/downloads/)
+* [pip](https://pip.pypa.io/en/stable/installation/)
 * [Virtualenv](https://virtualenv.pypa.io/en/latest/installation.html)
 * [docker](https://www.docker.com/)
-* [docker-compose](https://docs.docker.com/compose/)
+* [docker compose](https://docs.docker.com/compose/)
 
 ### Clone repository and install dependencies
 Clone the repository and open the root directory of the project:
@@ -39,9 +40,9 @@ pip install -r requirements.txt
 ```
 
 ### Start Docker containers (skip this if you use Scylla Cloud)
-Spin up a local ScyllaDB cluster with three nodes using `docker` and `docker-compose`:
+Spin up a local ScyllaDB cluster with three nodes using `docker` and `docker compose`:
 ```bash
-docker-compose up -d
+docker compose up -d
 
 Creating carepet-scylla3 ... done
 Creating carepet-scylla2 ... done
@@ -74,6 +75,9 @@ docker inspect carepet-scylla1
 ```
 
 ### Connect to ScyllaDB and create the database schema
+
+#### Local Docker cluster
+
 To connect to your ScyllaDB storage within the container, you need to know the
 IP address of one of the running nodes.
 This is how you can get the IP address of the first node running in the container:
@@ -90,6 +94,19 @@ NODE1=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{en
 Now you can run the migration script that creates the required keyspace and tables:
 ```bash
 python src/migrate.py -h $NODE1
+
+Creating keyspace...
+Done.
+Migrating database...
+Done.
+```
+
+#### ScyllaDB Cloud
+
+When using ScyllaDB Cloud, pass your cluster's contact point, username, password,
+and data center name:
+```bash
+python src/migrate.py -h <node-address> -u <username> -p <password> -d <datacenter>
 
 Creating keyspace...
 Done.
@@ -148,6 +165,8 @@ At this point you have ScyllaDB running with the correct keyspace and tables.
 Start ingesting IoT data (it's suggested to do this in a new separate terminal
 because this process runs indefinitely). Make sure you're still in the virtual
 environment:
+
+**Local Docker cluster:**
 ```bash
 source env/bin/activate
 NODE1=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' carepet-scylla1)
@@ -162,18 +181,22 @@ sensor # b6155934-bd4e-47de-8649-1fad447aa036 type T, new measure: 100.551184314
 sensor # d2c62c4d-9621-469d-b62c-41ef2271fca7 type L, new measure: 37.486651732296835, ts: 2023-01-08 17:36:17.126516
 ```
 
+**ScyllaDB Cloud:**
+```bash
+source env/bin/activate
+python src/sensor.py -h <node-address> -u <username> -p <password> -d <datacenter> --measure 2 --buffer-interval 10
+```
+
 This command starts a script that generates and ingests random IoT data coming
 from two sensors every other second and inserts the data in batches
 every ten seconds. Whenever you see `Pushing data` in the command line that is
-when data actually gets insterted into ScyllaDB.
+when data actually gets inserted into ScyllaDB.
 
 Optional: You can modify the frequency of the generated data by changing the
 `--measure` and `--buffer-interval` arguments. For example,
 you can generate new data points every three seconds and insert the batches
 every 30 seconds:
 ```bash
-source env/bin/activate
-NODE1=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' carepet-scylla1)
 python src/sensor.py -h $NODE1 --measure 3 --buffer-interval 30
 ```
 
@@ -181,6 +204,8 @@ You can run multiple ingestion processes in parallel if you wish.
 
 ### Set up and test REST API
 In a new terminal, start running the API server (make sure that `port 8000` is free):
+
+**Local Docker cluster:**
 ```bash
 source env/bin/activate
 NODE1=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' carepet-scylla1)
@@ -189,7 +214,13 @@ python src/api.py -h $NODE1
 INFO:     Started server process [696274]
 INFO:     Waiting for application startup.
 INFO:     Application startup complete.
-INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
+```
+
+**ScyllaDB Cloud:**
+```bash
+source env/bin/activate
+python src/api.py -h <node-address> -u <username> -p <password> -d <datacenter>
 ```
 
 The API server is running on `http://127.0.0.1:8000`. Test with your
@@ -215,8 +246,6 @@ To test these endpoints, you need to provide either an `owner_id` or a `pet_id`
 as URL path parameter. You can get these values by copying them from the
 beginning of output of the ingestion script:
 ```bash
-source env/bin/activate
-NODE1=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' carepet-scylla1)
 python src/sensor.py -h $NODE1 --measure 1 --buffer-interval 6
 
 Welcome to the Pet collar simulator
@@ -273,3 +302,4 @@ Package structure:
 | [/src/api.py](/src/api.py )             | Script to start the API server       |
 | [/src/migrate.py](/src/migrate.py)      | Schema creation                      |
 | [/src/sensor.py](/src/sensor.py)        | IoT data ingestion                   |
+| [/src/dognames.py](/src/dognames.py)    | Dog name generator utility           |

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,4 @@
-scylla-driver==3.25.11
-dognames==1.0.2
+scylla-driver>=3.29.0
 names==0.3.0
-fastapi==0.89.0
-uvicorn==0.20.0
+fastapi>=0.100.0
+uvicorn>=0.23.0

--- a/python/src/api.py
+++ b/python/src/api.py
@@ -1,4 +1,4 @@
 import uvicorn
 
 if __name__ == '__main__':
-    uvicorn.run("server.app:app")
+    uvicorn.run("server.app:app", host="0.0.0.0", port=8000)

--- a/python/src/db/client.py
+++ b/python/src/db/client.py
@@ -29,15 +29,18 @@ class ScyllaClient():
     def _get_cluster(self, config):
         profile = ExecutionProfile(
             load_balancing_policy=TokenAwarePolicy(
-                    DCAwareRoundRobinPolicy(local_dc=config["datacenter"])
+                    DCAwareRoundRobinPolicy(local_dc=config.get("datacenter"))
                 ),
                 row_factory=dict_factory
             )
+        auth_provider = None
+        if config.get("username") and config.get("password"):
+            auth_provider = PlainTextAuthProvider(username=config["username"],
+                                                  password=config["password"])
         return Cluster(
             execution_profiles={EXEC_PROFILE_DEFAULT: profile},
             contact_points=[config["hosts"]],
-            auth_provider = PlainTextAuthProvider(username=config["username"],
-                                                  password=config["password"]))
+            auth_provider=auth_provider)
     
     def print_metadata(self):
         for host in self.cluster.metadata.all_hosts():

--- a/python/src/db/cql/keyspace.cql
+++ b/python/src/db/cql/keyspace.cql
@@ -1,1 +1,1 @@
-CREATE KEYSPACE IF NOT EXISTS carepet;
+CREATE KEYSPACE IF NOT EXISTS carepet WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '3'} AND durable_writes = true;

--- a/python/src/dognames.py
+++ b/python/src/dognames.py
@@ -1,0 +1,42 @@
+"""
+Simple dog name generator replacing the unavailable `dognames` PyPI package.
+Provides male() and female() functions that return a random dog name.
+"""
+import random
+
+_MALE_NAMES = [
+    "Ace", "Apollo", "Archie", "Atlas", "Axel", "Bailey", "Bear", "Beau",
+    "Bentley", "Blue", "Bo", "Boomer", "Bruno", "Brute", "Brutus", "Buck",
+    "Buddy", "Buster", "Caesar", "Cash", "Charlie", "Chase", "Chester",
+    "Chief", "Chip", "Cody", "Cooper", "Copper", "Cosmo", "Diesel", "Duke",
+    "Elvis", "Finn", "Frank", "Gage", "Goliath", "Gus", "Hank", "Harley",
+    "Henry", "Hugo", "Hunter", "Jack", "Jax", "Joey", "Koda", "Leo", "Loki",
+    "Lucky", "Mac", "Max", "Maverick", "Miles", "Moose", "Murphy", "Oscar",
+    "Otis", "Rex", "Riley", "Rocky", "Roscoe", "Rufus", "Rusty", "Sam",
+    "Scout", "Shadow", "Simba", "Spike", "Tank", "Thor", "Toby", "Tucker",
+    "Tyson", "Zeus",
+]
+
+_FEMALE_NAMES = [
+    "Abby", "Angel", "Athena", "Aurora", "Autumn", "Ava", "Babette", "Bailey",
+    "Bella", "Bessie", "Birdie", "Blondie", "Bonnie", "Brandy", "Brie",
+    "Brownie", "Candy", "Carla", "Chelsea", "Chloe", "Cleo", "Coco", "Cookie",
+    "Daisy", "Dakota", "Darla", "Diva", "Dolly", "Elsie", "Emma", "Fiona",
+    "Ginger", "Gracie", "Greta", "Harley", "Hazel", "Holly", "Honey", "Jade",
+    "Jasmine", "Jessie", "Lady", "Lexi", "Lily", "Lola", "Lucy", "Luna",
+    "Lulu", "Macy", "Maggie", "Maple", "Maya", "Mia", "Millie", "Minnie",
+    "Missy", "Molly", "Nala", "Nora", "Olivia", "Peanut", "Pebbles", "Penny",
+    "Pepper", "Piper", "Pixie", "Princess", "Rosie", "Roxie", "Ruby", "Sadie",
+    "Sandy", "Sasha", "Stella", "Sugar", "Trixie", "Violet", "Willow", "Zara",
+    "Zoe",
+]
+
+
+def male():
+    """Return a random male dog name."""
+    return random.choice(_MALE_NAMES)
+
+
+def female():
+    """Return a random female dog name."""
+    return random.choice(_FEMALE_NAMES)

--- a/python/src/migrate.py
+++ b/python/src/migrate.py
@@ -2,27 +2,32 @@ import os
 from db import config
 from db.client import ScyllaClient
 
-arg_parser = config.argument_parser()
-db_config = vars(arg_parser.parse_args())
-client = ScyllaClient(db_config)
-session = client.get_session()
-
 
 def absolute_file_path(relative_file_path):
     current_dir = os.path.dirname(__file__)
     return os.path.join(current_dir, relative_file_path)
 
 
-print("Creating keyspace...")
-with open(absolute_file_path("db/cql/keyspace.cql"), "r") as file:
-    session.execute(file.read())
-print("Done.")
+def main():
+    arg_parser = config.argument_parser()
+    db_config = vars(arg_parser.parse_args())
+    client = ScyllaClient(db_config)
+    session = client.get_session()
 
-print("Migrating database...")
-with open(absolute_file_path("db/cql/migrate.cql"), "r") as file:
-    for query in file.read().split(";"):
-        if len(query) > 0:
-            session.execute(query)
-print("Done.")
+    print("Creating keyspace...")
+    with open(absolute_file_path("db/cql/keyspace.cql"), "r") as file:
+        session.execute(file.read())
+    print("Done.")
 
-client.shutdown()
+    print("Migrating database...")
+    with open(absolute_file_path("db/cql/migrate.cql"), "r") as file:
+        for query in file.read().split(";"):
+            if len(query.strip()) > 0:
+                session.execute(query)
+    print("Done.")
+
+    client.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/src/sensor.py
+++ b/python/src/sensor.py
@@ -130,4 +130,5 @@ def main():
             print("Pushing data")
             client.insert_batch_data("carepet.measurement", measurements_data)
         
-main()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR fixes several issues in the Python example that prevented it from running on modern Python (3.8+) and with ScyllaDB Cloud.

### Issues fixed

**Critical (breaks install/runtime):**
- `scylla-driver==3.25.11` fails to build on Python 3.12 due to a `TarFile.chown()` API change in its bundled `ez_setup.py`. Updated to `>=3.29.0`.
- `dognames==1.0.2` does not exist on PyPI — install always fails. Replaced with `src/dognames.py`, a self-contained module that provides the same `male()`/`female()` API using a hardcoded list of dog names.

**Logic / correctness:**
- `keyspace.cql` used bare `CREATE KEYSPACE IF NOT EXISTS carepet;` which is invalid CQL on a local ScyllaDB node (replication strategy is required). Added explicit `NetworkTopologyStrategy` with `replication_factor = 3`.
- `client.py` always constructed `PlainTextAuthProvider` even when no credentials were provided, causing errors on unauthenticated local clusters. Auth provider is now only attached when `--username` and `--password` are supplied.
- `migrate.py` and `sensor.py` ran top-level code on import (no `__main__` guard). Refactored both into proper `main()` functions with guards.
- `migrate.py`'s CQL splitter used `len(query) > 0` instead of `len(query.strip()) > 0`, causing empty/whitespace-only strings to be sent as queries.
- `api.py` bound uvicorn to `127.0.0.1` (default), making the server unreachable in Docker. Changed to `0.0.0.0`.

**Dependencies:**
- Updated `fastapi` to `>=0.100.0` and `uvicorn` to `>=0.23.0`.

**Docs (README + tutorial):**
- Added ScyllaDB Cloud auth instructions (`-u`/`-p`/`-d` flags) to all command examples.
- Replaced `docker-compose` with `docker compose` (Compose V2).
- Bumped Python prerequisite from 3.7+ to 3.8+.
- Fixed typo: _insterted_ → _inserted_.
- Added `dognames.py` to the structure table.