### PR TITLE
Add C++ example for the care-pet IoT demo

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,63 @@
+cmake_minimum_required(VERSION 3.14)
+project(care-pet-cpp VERSION 1.0.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+add_compile_definitions(_GNU_SOURCE)
+
+include(FetchContent)
+
+# cpp-httplib
+FetchContent_Declare(
+    httplib
+    GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
+    GIT_TAG v0.15.3
+)
+FetchContent_MakeAvailable(httplib)
+
+# nlohmann/json
+FetchContent_Declare(
+    nlohmann_json
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
+    GIT_TAG v3.11.3
+)
+FetchContent_MakeAvailable(nlohmann_json)
+
+# ScyllaDB C++ driver
+# The scylladb/cpp-driver installs as libscylla-cpp-driver on Linux.
+find_library(CASSANDRA_LIB
+    NAMES scylla-cpp-driver cassandra
+    PATHS
+        /usr/local/lib/x86_64-linux-gnu
+        /usr/local/lib
+        /usr/lib/x86_64-linux-gnu
+        /usr/lib
+    REQUIRED)
+find_path(CASSANDRA_INCLUDE_DIR
+    NAMES cassandra.h
+    PATHS /usr/local/include /usr/include
+    REQUIRED)
+
+get_filename_component(CASSANDRA_LIB_DIR "${CASSANDRA_LIB}" DIRECTORY)
+link_directories(${CASSANDRA_LIB_DIR})
+
+add_library(cassandra_driver INTERFACE)
+target_include_directories(cassandra_driver INTERFACE "${CASSANDRA_INCLUDE_DIR}")
+# Use the stem (strip lib prefix and .so suffix) so the linker gets -lscylla-cpp-driver
+get_filename_component(CASSANDRA_LIB_NAME "${CASSANDRA_LIB}" NAME_WE)
+string(REPLACE "lib" "" CASSANDRA_LINK_NAME "${CASSANDRA_LIB_NAME}")
+target_link_libraries(cassandra_driver INTERFACE ${CASSANDRA_LINK_NAME})
+
+include_directories(${CMAKE_SOURCE_DIR}/include)
+
+# migrate
+add_executable(migrate cmd/migrate/main.cpp)
+target_link_libraries(migrate PRIVATE cassandra_driver)
+
+# sensor
+add_executable(sensor cmd/sensor/main.cpp)
+target_link_libraries(sensor PRIVATE cassandra_driver)
+
+# server
+add_executable(server cmd/server/main.cpp)
+target_link_libraries(server PRIVATE cassandra_driver httplib::httplib nlohmann_json::nlohmann_json)

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:22.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    cmake g++ git libssl-dev libuv1-dev zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build ScyllaDB C++ driver from source
+WORKDIR /deps
+RUN git clone --depth 1 --branch master https://github.com/scylladb/cpp-driver.git && \
+    cmake -B cpp-driver/build -S cpp-driver \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DCASS_BUILD_SHARED=ON \
+        -DCASS_BUILD_STATIC=OFF && \
+    cmake --build cpp-driver/build --parallel && \
+    cmake --install cpp-driver/build && \
+    ldconfig
+
+WORKDIR /app
+COPY . .
+RUN cmake -B build -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build --parallel
+
+# ---------------------------------------------------------------------------
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y libuv1 libssl3 && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/lib/x86_64-linux-gnu/libscylla-cpp-driver.so* /usr/local/lib/x86_64-linux-gnu/
+COPY --from=builder /app/build/migrate \
+                    /app/build/sensor  \
+                    /app/build/server  \
+                    /usr/local/bin/
+RUN ldconfig
+
+CMD ["server"]

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -1,0 +1,248 @@
+# Care-Pet C++
+
+ScyllaDB IoT demo application written in C++17 using the
+[ScyllaDB C++ Driver](https://github.com/scylladb/cpp-driver).  
+It models a pet health monitoring collar that streams sensor readings
+(temperature, pulse, respiration, location) into ScyllaDB and exposes
+them through a REST API.
+
+```
+┌──────────────┐   INSERT measurements    ┌──────────────────┐
+│    sensor    │ ─────────────────────────▶│                  │
+│ (collar sim) │                           │    ScyllaDB      │
+└──────────────┘                           │    cluster       │
+                                           │                  │
+┌──────────────┐   SELECT / INSERT avgs   │                  │
+│    server    │◀─────────────────────────▶│                  │
+│  (REST API)  │                           └──────────────────┘
+└──────────────┘
+        ▲
+        │  HTTP/JSON
+        ▼
+   curl / client
+```
+
+---
+
+## Prerequisites
+
+| Tool | Version |
+|------|---------|
+| CMake | ≥ 3.14 |
+| C++ compiler | GCC ≥ 9 or Clang ≥ 10 (C++17) |
+| libuv | ≥ 1.x |
+| OpenSSL | ≥ 1.1 |
+| Docker + docker-compose | any recent version |
+
+> **ScyllaDB C++ Driver** is fetched and built automatically inside the
+> Docker image.  For a local build install the driver first – see
+> [driver installation](https://github.com/scylladb/cpp-driver#installation).
+
+---
+
+## Quick Start (Docker)
+
+```bash
+# 1. Start a 3-node ScyllaDB cluster + build the app image
+docker-compose up -d
+
+# 2. Wait for ScyllaDB to be ready (≈ 60 s)
+docker exec carepet-scylla1 nodetool status
+
+# 3. Run migrate inside the app container
+docker exec carepet-cpp migrate --hosts carepet-scylla1
+
+# 4. Start the collar simulator (background)
+docker exec -d carepet-cpp sensor --hosts carepet-scylla1
+
+# 5. Start the REST server
+docker exec -d carepet-cpp server --hosts carepet-scylla1 --port 8000
+```
+
+---
+
+## Local Build
+
+```bash
+# Install driver (Ubuntu/Debian example)
+# See https://github.com/scylladb/cpp-driver for your platform.
+
+git clone https://github.com/scylladb/cpp-driver.git
+cmake -B cpp-driver/build -S cpp-driver -DCMAKE_BUILD_TYPE=Release \
+      -DCASS_BUILD_SHARED=ON -DCASS_BUILD_STATIC=OFF
+cmake --build cpp-driver/build --parallel
+sudo cmake --install cpp-driver/build
+
+# Build care-pet binaries
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel
+```
+
+The three binaries are placed in `build/`:
+
+```
+build/migrate
+build/sensor
+build/server
+```
+
+---
+
+## Running
+
+### 1. Migrate
+
+Creates the `carepet` keyspace and all tables.
+
+```bash
+./build/migrate [--hosts 127.0.0.1] [--username u] [--password p]
+```
+
+```
+Connecting to 127.0.0.1 ...
+Creating keyspace 'carepet' ...
+  OK
+Creating table 'owner' ...
+  OK
+...
+Migration complete.
+```
+
+### 2. Sensor Simulator
+
+Generates a random owner + pet + 2–4 sensors, inserts them, then streams
+measurements in a loop.
+
+```bash
+./build/sensor \
+  [--hosts 127.0.0.1] \
+  [--measure 5s]          # how often to sample (s/m/h)
+  [--buffer-interval 1m]  # how often to flush to DB
+```
+
+```
+New owner # 3d6c7e2a-...
+New pet    # a1b2c3d4-...
+  Sensor [T] # 11111111-...
+  Sensor [P] # 22222222-...
+Sensor loop started (measure every 5s, flush every 60s) ...
+[T] 11111111-... = 101.34
+[P] 22222222-... = 97.12
+...
+Flushing 24 measurement(s) to ScyllaDB ...
+```
+
+Duration strings: `5s` = 5 seconds, `1m` = 60 seconds, `2h` = 7200 seconds.
+
+### 3. Server
+
+```bash
+./build/server \
+  [--hosts 127.0.0.1] \
+  [--port 8000]
+```
+
+---
+
+## REST API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/owner/{uuid}` | Fetch owner by ID |
+| GET | `/api/owner/{uuid}/pets` | List pets for an owner |
+| GET | `/api/pet/{uuid}/sensors` | List sensors for a pet |
+| GET | `/api/sensor/{uuid}/values?from=T&to=T` | Raw readings in time range |
+| GET | `/api/sensor/{uuid}/values/day/{YYYY-MM-DD}` | 24 hourly averages |
+
+Timestamps use ISO 8601: `2024-01-15T12:00:00Z`.
+
+### Examples
+
+```bash
+# Get owner
+curl http://localhost:8000/api/owner/3d6c7e2a-0000-0000-0000-000000000000
+
+# List pets
+curl http://localhost:8000/api/owner/3d6c7e2a-.../pets
+
+# List sensors
+curl http://localhost:8000/api/pet/a1b2c3d4-.../sensors
+
+# Readings in range
+curl "http://localhost:8000/api/sensor/11111111-.../values?from=2024-01-15T00:00:00Z&to=2024-01-15T23:59:59Z"
+# → [101.34, 99.87, ...]
+
+# Hourly averages for a day (computed on demand + cached in sensor_avg)
+curl http://localhost:8000/api/sensor/11111111-.../values/day/2024-01-15
+# → [0,0,0,...,101.1,100.3,...,0]  (24 floats)
+```
+
+---
+
+## ScyllaDB Cloud
+
+ScyllaDB Cloud clusters use username/password authentication over standard
+CQL (port 9042, no SSL required). Set the connection details via environment
+variables or CLI flags:
+
+```bash
+export SCYLLADB_HOSTS=node-0.aws-us-east-1.xxx.clusters.scylla.cloud
+export SCYLLADB_USERNAME=scylla
+export SCYLLADB_PASSWORD=secret
+./build/migrate
+./build/sensor --measure 5s --buffer-interval 1m
+```
+
+Environment variables `SCYLLADB_HOSTS`, `SCYLLADB_USERNAME`, and
+`SCYLLADB_PASSWORD` are read first; CLI flags (`--hosts`, `--username`,
+`--password`) override them.
+
+---
+
+## Project Structure
+
+```
+cpp/
+├── CMakeLists.txt          # Build configuration
+├── Dockerfile              # Multi-stage Docker build
+├── docker-compose.yml      # 3-node ScyllaDB cluster + app
+├── db/
+│   ├── keyspace.cql        # CREATE KEYSPACE statement
+│   └── schema.cql          # CREATE TABLE statements
+├── include/
+│   ├── config.hpp          # Config struct + RAII Session wrapper
+│   ├── model.hpp           # C++ data-model structs
+│   └── rand_util.hpp       # Random test-data generators
+└── cmd/
+    ├── migrate/main.cpp    # Keyspace + schema migration
+    ├── sensor/main.cpp     # Collar simulator
+    └── server/main.cpp     # REST API server
+```
+
+---
+
+## Implementation Notes
+
+* **Driver API** — The ScyllaDB C++ Driver exposes a pure C API (`cassandra.h`).
+  `config.hpp` wraps the raw `CassCluster` / `CassSession` pair in a RAII
+  `Session` class that throws `std::runtime_error` on failure.
+
+* **Prepared statements** — The sensor simulator prepares the measurement
+  `INSERT` once and reuses the `CassPrepared*` for every write, avoiding
+  repeated parse/plan overhead.
+
+* **Hourly averages** — The `/values/day/{date}` endpoint first checks
+  `sensor_avg`.  If no rows are found it falls back to computing averages
+  from raw `measurement` rows, stores the result in `sensor_avg`, then
+  returns the 24-element array.
+
+* **Thread safety** — `CassSession` is thread-safe; cpp-httplib dispatches
+  requests from a thread pool and each handler creates its own local
+  `CassStatement` / `CassResult` objects.
+
+* **CQL DATE** — Stored as `uint32_t` days since the Unix epoch
+  (1970-01-01).  `parse_date_days()` in the server converts an ISO date
+  string using POSIX `timegm`.
+
+* **CQL TIMESTAMP** — Stored as `int64_t` milliseconds since the Unix
+  epoch, matching the C++ `std::chrono::system_clock` representation.

--- a/cpp/cmd/migrate/main.cpp
+++ b/cpp/cmd/migrate/main.cpp
@@ -1,0 +1,100 @@
+#include "config.hpp"
+
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// DDL statements executed in order.
+// ---------------------------------------------------------------------------
+static const std::string KEYSPACE_DDL =
+    "CREATE KEYSPACE IF NOT EXISTS carepet"
+    " WITH replication = {'class':'NetworkTopologyStrategy','replication_factor':'3'}"
+    " AND durable_writes = TRUE";
+
+static const std::vector<std::pair<std::string, std::string>> TABLE_DDLS = {
+    {"owner",
+     "CREATE TABLE IF NOT EXISTS carepet.owner ("
+     " owner_id UUID,"
+     " address TEXT,"
+     " name TEXT,"
+     " PRIMARY KEY (owner_id)"
+     ")"},
+
+    {"pet",
+     "CREATE TABLE IF NOT EXISTS carepet.pet ("
+     " owner_id UUID,"
+     " pet_id UUID,"
+     " chip_id TEXT,"
+     " species TEXT,"
+     " breed TEXT,"
+     " color TEXT,"
+     " gender TEXT,"
+     " age INT,"
+     " weight FLOAT,"
+     " address TEXT,"
+     " name TEXT,"
+     " PRIMARY KEY (owner_id, pet_id)"
+     ")"},
+
+    {"sensor",
+     "CREATE TABLE IF NOT EXISTS carepet.sensor ("
+     " pet_id UUID,"
+     " sensor_id UUID,"
+     " type TEXT,"
+     " PRIMARY KEY (pet_id, sensor_id)"
+     ")"},
+
+    {"measurement",
+     "CREATE TABLE IF NOT EXISTS carepet.measurement ("
+     " sensor_id UUID,"
+     " ts TIMESTAMP,"
+     " value FLOAT,"
+     " PRIMARY KEY (sensor_id, ts)"
+     ") WITH compaction = {'class':'TimeWindowCompactionStrategy'}"},
+
+    {"sensor_avg",
+     "CREATE TABLE IF NOT EXISTS carepet.sensor_avg ("
+     " sensor_id UUID,"
+     " date DATE,"
+     " hour INT,"
+     " value FLOAT,"
+     " PRIMARY KEY (sensor_id, date, hour)"
+     ") WITH compaction = {'class':'TimeWindowCompactionStrategy'}"},
+};
+
+int main(int argc, char** argv) {
+    try {
+        Config cfg;
+        cfg.parse_args(argc, argv);
+
+        std::cout << "Connecting to " << cfg.hosts << " ...\n";
+
+        // Step 1: connect without a keyspace and create it.
+        {
+            Session s;
+            s.connect(cfg);
+            std::cout << "Creating keyspace 'carepet' ...\n";
+            s.execute(KEYSPACE_DDL);
+            std::cout << "  OK\n";
+        }
+
+        // Step 2: connect to the keyspace and create all tables.
+        {
+            Session s;
+            s.connect_keyspace(cfg, "carepet");
+            for (auto& [name, ddl] : TABLE_DDLS) {
+                std::cout << "Creating table '" << name << "' ...\n";
+                s.execute(ddl);
+                std::cout << "  OK\n";
+            }
+        }
+
+        std::cout << "Migration complete.\n";
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << "\n";
+        return 1;
+    }
+    return 0;
+}

--- a/cpp/cmd/sensor/main.cpp
+++ b/cpp/cmd/sensor/main.cpp
@@ -1,0 +1,229 @@
+#include "config.hpp"
+#include "model.hpp"
+#include "rand_util.hpp"
+
+#include <cassandra.h>
+
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static int64_t now_ms() {
+    using namespace std::chrono;
+    return duration_cast<milliseconds>(
+               system_clock::now().time_since_epoch())
+        .count();
+}
+
+// Parse simple duration strings like "5s", "1m", "2h" → seconds.
+static int parse_duration_secs(const std::string& s) {
+    if (s.empty()) return 0;
+    char unit = s.back();
+    int  val  = std::stoi(s.substr(0, s.size() - 1));
+    if (unit == 's') return val;
+    if (unit == 'm') return val * 60;
+    if (unit == 'h') return val * 3600;
+    return std::stoi(s); // no unit → treat as seconds
+}
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+static void exec_stmt(CassSession* session, CassStatement* stmt, const char* ctx) {
+    CassFuture* f = cass_session_execute(session, stmt);
+    cass_statement_free(stmt);
+    cass_future_wait(f);
+    CassError rc = cass_future_error_code(f);
+    if (rc != CASS_OK) {
+        const char* msg; size_t len;
+        cass_future_error_message(f, &msg, &len);
+        std::string err(msg, len);
+        cass_future_free(f);
+        throw std::runtime_error(std::string(ctx) + ": " + err);
+    }
+    cass_future_free(f);
+}
+
+static void insert_owner(CassSession* session, const Owner& o) {
+    const char* q =
+        "INSERT INTO carepet.owner (owner_id, address, name) VALUES (?, ?, ?)";
+    CassStatement* stmt = cass_statement_new(q, 3);
+    cass_statement_bind_uuid(stmt, 0, o.owner_id);
+    cass_statement_bind_string(stmt, 1, o.address.c_str());
+    cass_statement_bind_string(stmt, 2, o.name.c_str());
+    exec_stmt(session, stmt, "insert_owner");
+}
+
+static void insert_pet(CassSession* session, const Pet& p) {
+    const char* q =
+        "INSERT INTO carepet.pet"
+        " (owner_id, pet_id, chip_id, species, breed, color, gender, age, weight, address, name)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    CassStatement* stmt = cass_statement_new(q, 11);
+    cass_statement_bind_uuid(stmt,   0, p.owner_id);
+    cass_statement_bind_uuid(stmt,   1, p.pet_id);
+    cass_statement_bind_string(stmt, 2, p.chip_id.c_str());
+    cass_statement_bind_string(stmt, 3, p.species.c_str());
+    cass_statement_bind_string(stmt, 4, p.breed.c_str());
+    cass_statement_bind_string(stmt, 5, p.color.c_str());
+    cass_statement_bind_string(stmt, 6, p.gender.c_str());
+    cass_statement_bind_int32(stmt,  7, static_cast<cass_int32_t>(p.age));
+    cass_statement_bind_float(stmt,  8, p.weight);
+    cass_statement_bind_string(stmt, 9, p.address.c_str());
+    cass_statement_bind_string(stmt,10, p.name.c_str());
+    exec_stmt(session, stmt, "insert_pet");
+}
+
+static void insert_sensor(CassSession* session, const Sensor& s) {
+    const char* q =
+        "INSERT INTO carepet.sensor (pet_id, sensor_id, type) VALUES (?, ?, ?)";
+    CassStatement* stmt = cass_statement_new(q, 3);
+    cass_statement_bind_uuid(stmt,   0, s.pet_id);
+    cass_statement_bind_uuid(stmt,   1, s.sensor_id);
+    cass_statement_bind_string(stmt, 2, s.type.c_str());
+    exec_stmt(session, stmt, "insert_sensor");
+}
+
+// Flush buffered measurements using a prepared statement.
+static void flush_measurements(CassSession* session,
+                                const CassPrepared* prep,
+                                const std::vector<Measurement>& buf) {
+    for (const auto& m : buf) {
+        CassStatement* stmt = cass_prepared_bind(prep);
+        cass_statement_bind_uuid(stmt,  0, m.sensor_id);
+        cass_statement_bind_int64(stmt, 1, m.ts);
+        cass_statement_bind_float(stmt, 2, m.value);
+
+        CassFuture* f = cass_session_execute(session, stmt);
+        cass_statement_free(stmt);
+        cass_future_wait(f);
+        CassError rc = cass_future_error_code(f);
+        if (rc != CASS_OK) {
+            const char* msg; size_t len;
+            cass_future_error_message(f, &msg, &len);
+            std::cerr << "Warning: insert measurement failed: "
+                      << std::string(msg, len) << "\n";
+        }
+        cass_future_free(f);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+int main(int argc, char** argv) {
+    try {
+        Config cfg;
+        cfg.parse_args(argc, argv);
+
+        // Parse sensor-specific flags.
+        int measure_secs = 5;
+        int buffer_secs  = 60;
+        for (int i = 1; i + 1 < argc; ++i) {
+            std::string a = argv[i];
+            while (!a.empty() && a.front() == '-') a.erase(0, 1);
+            if      (a == "measure")         measure_secs = parse_duration_secs(argv[i + 1]);
+            else if (a == "buffer-interval") buffer_secs  = parse_duration_secs(argv[i + 1]);
+        }
+
+        std::cout << "Connecting to " << cfg.hosts << " ...\n";
+        Session session;
+        session.connect_keyspace(cfg, "carepet");
+
+        // Generate random owner / pet / sensors.
+        CassUuidGen* uuid_gen = cass_uuid_gen_new();
+        Owner owner = rand_owner(uuid_gen);
+        Pet   pet   = rand_pet(uuid_gen, owner);
+
+        int num_sensors = rand_int(2, 4);
+        std::vector<Sensor> sensors;
+        sensors.reserve(num_sensors);
+        for (int i = 0; i < num_sensors; ++i)
+            sensors.push_back(rand_sensor(uuid_gen, pet));
+
+        // Persist initial data.
+        insert_owner(session.get(), owner);
+        insert_pet(session.get(), pet);
+        for (const auto& s : sensors)
+            insert_sensor(session.get(), s);
+
+        std::cout << "New owner # " << uuid_to_string(owner.owner_id) << "\n";
+        std::cout << "New pet    # " << uuid_to_string(pet.pet_id) << "\n";
+        for (const auto& s : sensors)
+            std::cout << "  Sensor [" << s.type << "] # "
+                      << uuid_to_string(s.sensor_id) << "\n";
+
+        // Prepare measurement INSERT once.
+        const char* mq =
+            "INSERT INTO carepet.measurement (sensor_id, ts, value) VALUES (?, ?, ?)";
+        CassFuture* pf = cass_session_prepare(session.get(), mq);
+        cass_future_wait(pf);
+        CassError prc = cass_future_error_code(pf);
+        if (prc != CASS_OK) {
+            const char* msg; size_t len;
+            cass_future_error_message(pf, &msg, &len);
+            std::string err(msg, len);
+            cass_future_free(pf);
+            throw std::runtime_error("prepare failed: " + err);
+        }
+        const CassPrepared* prepared = cass_future_get_prepared(pf);
+        cass_future_free(pf);
+
+        using namespace std::chrono;
+        auto measure_dur = seconds(measure_secs);
+        auto buffer_dur  = seconds(buffer_secs);
+        auto last_measure = steady_clock::now();
+        auto last_flush   = steady_clock::now();
+
+        std::vector<Measurement> buffer;
+
+        std::cout << "Sensor loop started (measure every " << measure_secs
+                  << "s, flush every " << buffer_secs << "s) ...\n";
+
+        while (true) {
+            auto now = steady_clock::now();
+
+            if (now - last_measure >= measure_dur) {
+                for (const auto& s : sensors) {
+                    Measurement m;
+                    m.sensor_id = s.sensor_id;
+                    m.ts        = now_ms();
+                    m.value     = rand_sensor_data(s);
+                    buffer.push_back(m);
+                    std::cout << "[" << s.type << "] "
+                              << uuid_to_string(s.sensor_id)
+                              << " = " << m.value << "\n";
+                }
+                last_measure = now;
+            }
+
+            if (now - last_flush >= buffer_dur) {
+                if (!buffer.empty()) {
+                    std::cout << "Flushing " << buffer.size()
+                              << " measurement(s) to ScyllaDB ...\n";
+                    flush_measurements(session.get(), prepared, buffer);
+                    buffer.clear();
+                }
+                last_flush = now;
+            }
+
+            std::this_thread::sleep_for(milliseconds(100));
+        }
+
+        // Unreachable in normal operation; reached only after SIGINT / clean exit.
+        cass_prepared_free(prepared);
+        cass_uuid_gen_free(uuid_gen);
+
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << "\n";
+        return 1;
+    }
+    return 0;
+}

--- a/cpp/cmd/server/main.cpp
+++ b/cpp/cmd/server/main.cpp
@@ -1,0 +1,419 @@
+#include "config.hpp"
+#include "model.hpp"
+
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+
+#include <cassandra.h>
+#include <ctime>
+
+#include <array>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using json = nlohmann::json;
+
+// ---------------------------------------------------------------------------
+// Low-level helpers
+// ---------------------------------------------------------------------------
+
+// Execute a bound statement and return the result (caller must cass_result_free).
+static const CassResult* execute_query(CassSession* session, CassStatement* stmt) {
+    CassFuture* f = cass_session_execute(session, stmt);
+    cass_future_wait(f);
+    CassError rc = cass_future_error_code(f);
+    if (rc != CASS_OK) {
+        const char* msg; size_t len;
+        cass_future_error_message(f, &msg, &len);
+        std::string err(msg, len);
+        cass_future_free(f);
+        throw std::runtime_error("query failed: " + err);
+    }
+    const CassResult* result = cass_future_get_result(f);
+    cass_future_free(f);
+    return result;
+}
+
+// Execute a statement without collecting results (fire-and-forget, logs errors).
+static void execute_void(CassSession* session, CassStatement* stmt) {
+    CassFuture* f = cass_session_execute(session, stmt);
+    cass_statement_free(stmt);
+    cass_future_wait(f);
+    CassError rc = cass_future_error_code(f);
+    if (rc != CASS_OK) {
+        const char* msg; size_t len;
+        cass_future_error_message(f, &msg, &len);
+        std::cerr << "Warning: " << std::string(msg, len) << "\n";
+    }
+    cass_future_free(f);
+}
+
+static CassUuid parse_uuid(const std::string& s) {
+    CassUuid uuid;
+    if (cass_uuid_from_string(s.c_str(), &uuid) != CASS_OK)
+        throw std::runtime_error("invalid UUID: " + s);
+    return uuid;
+}
+
+// "YYYY-MM-DDThh:mm:ssZ" or "YYYY-MM-DD" → milliseconds since Unix epoch.
+static int64_t parse_timestamp_ms(const std::string& s) {
+    struct tm tm = {};
+    const char* end = strptime(s.c_str(), "%Y-%m-%dT%H:%M:%SZ", &tm);
+    if (!end) end = strptime(s.c_str(), "%Y-%m-%dT%H:%M:%S", &tm);
+    if (!end) end = strptime(s.c_str(), "%Y-%m-%d", &tm);
+    if (!end) throw std::runtime_error("invalid timestamp: " + s);
+    return static_cast<int64_t>(timegm(&tm)) * 1000LL;
+}
+
+// "YYYY-MM-DD" → days since Unix epoch (CQL DATE representation).
+static uint32_t parse_date_days(const std::string& s) {
+    struct tm tm = {};
+    const char* end = strptime(s.c_str(), "%Y-%m-%d", &tm);
+    if (!end) throw std::runtime_error("invalid date: " + s);
+    return static_cast<uint32_t>(timegm(&tm) / 86400LL);
+}
+
+// ---------------------------------------------------------------------------
+// Row deserialization helpers
+// ---------------------------------------------------------------------------
+
+static std::string col_str(const CassRow* row, size_t idx) {
+    const char* v; size_t len;
+    cass_value_get_string(cass_row_get_column(row, idx), &v, &len);
+    return std::string(v, len);
+}
+
+// ---------------------------------------------------------------------------
+// Route handlers (lambdas capture session by reference)
+// ---------------------------------------------------------------------------
+
+// GET /api/owner/{id}
+static void handle_owner(CassSession* session,
+                          const httplib::Request& req,
+                          httplib::Response& res) {
+    CassUuid owner_id = parse_uuid(std::string(req.matches[1]));
+
+    const char* q =
+        "SELECT owner_id, address, name FROM carepet.owner WHERE owner_id = ?";
+    CassStatement* stmt = cass_statement_new(q, 1);
+    cass_statement_bind_uuid(stmt, 0, owner_id);
+    const CassResult* result = execute_query(session, stmt);
+    cass_statement_free(stmt);
+
+    if (cass_result_row_count(result) == 0) {
+        cass_result_free(result);
+        res.status = 404;
+        res.set_content("owner not found", "text/plain");
+        return;
+    }
+
+    const CassRow* row = cass_result_first_row(result);
+    Owner o;
+    cass_value_get_uuid(cass_row_get_column(row, 0), &o.owner_id);
+    o.address = col_str(row, 1);
+    o.name    = col_str(row, 2);
+    cass_result_free(result);
+
+    json j;
+    j["owner_id"] = uuid_to_string(o.owner_id);
+    j["address"]  = o.address;
+    j["name"]     = o.name;
+    res.set_content(j.dump(), "application/json");
+}
+
+// GET /api/owner/{id}/pets
+static void handle_owner_pets(CassSession* session,
+                               const httplib::Request& req,
+                               httplib::Response& res) {
+    CassUuid owner_id = parse_uuid(std::string(req.matches[1]));
+
+    const char* q =
+        "SELECT owner_id, pet_id, chip_id, species, breed, color, gender,"
+        " age, weight, address, name"
+        " FROM carepet.pet WHERE owner_id = ?";
+    CassStatement* stmt = cass_statement_new(q, 1);
+    cass_statement_bind_uuid(stmt, 0, owner_id);
+    const CassResult* result = execute_query(session, stmt);
+    cass_statement_free(stmt);
+
+    json arr = json::array();
+    CassIterator* it = cass_iterator_from_result(result);
+    while (cass_iterator_next(it)) {
+        const CassRow* row = cass_iterator_get_row(it);
+        Pet p;
+        cass_value_get_uuid(cass_row_get_column(row, 0), &p.owner_id);
+        cass_value_get_uuid(cass_row_get_column(row, 1), &p.pet_id);
+        p.chip_id = col_str(row, 2);
+        p.species = col_str(row, 3);
+        p.breed   = col_str(row, 4);
+        p.color   = col_str(row, 5);
+        p.gender  = col_str(row, 6);
+        cass_value_get_int32(cass_row_get_column(row, 7),
+                             reinterpret_cast<cass_int32_t*>(&p.age));
+        cass_value_get_float(cass_row_get_column(row, 8), &p.weight);
+        p.address = col_str(row, 9);
+        p.name    = col_str(row, 10);
+
+        json jp;
+        jp["owner_id"] = uuid_to_string(p.owner_id);
+        jp["pet_id"]   = uuid_to_string(p.pet_id);
+        jp["chip_id"]  = p.chip_id;
+        jp["species"]  = p.species;
+        jp["breed"]    = p.breed;
+        jp["color"]    = p.color;
+        jp["gender"]   = p.gender;
+        jp["age"]      = p.age;
+        jp["weight"]   = p.weight;
+        jp["address"]  = p.address;
+        jp["name"]     = p.name;
+        arr.push_back(jp);
+    }
+    cass_iterator_free(it);
+    cass_result_free(result);
+    res.set_content(arr.dump(), "application/json");
+}
+
+// GET /api/pet/{id}/sensors
+static void handle_pet_sensors(CassSession* session,
+                                const httplib::Request& req,
+                                httplib::Response& res) {
+    CassUuid pet_id = parse_uuid(std::string(req.matches[1]));
+
+    const char* q =
+        "SELECT pet_id, sensor_id, type FROM carepet.sensor WHERE pet_id = ?";
+    CassStatement* stmt = cass_statement_new(q, 1);
+    cass_statement_bind_uuid(stmt, 0, pet_id);
+    const CassResult* result = execute_query(session, stmt);
+    cass_statement_free(stmt);
+
+    json arr = json::array();
+    CassIterator* it = cass_iterator_from_result(result);
+    while (cass_iterator_next(it)) {
+        const CassRow* row = cass_iterator_get_row(it);
+        Sensor s;
+        cass_value_get_uuid(cass_row_get_column(row, 0), &s.pet_id);
+        cass_value_get_uuid(cass_row_get_column(row, 1), &s.sensor_id);
+        s.type = col_str(row, 2);
+
+        json js;
+        js["pet_id"]    = uuid_to_string(s.pet_id);
+        js["sensor_id"] = uuid_to_string(s.sensor_id);
+        js["type"]      = s.type;
+        arr.push_back(js);
+    }
+    cass_iterator_free(it);
+    cass_result_free(result);
+    res.set_content(arr.dump(), "application/json");
+}
+
+// GET /api/sensor/{id}/values?from=ISO8601&to=ISO8601  → array of floats
+static void handle_sensor_values(CassSession* session,
+                                  const httplib::Request& req,
+                                  httplib::Response& res) {
+    if (!req.has_param("from") || !req.has_param("to")) {
+        res.status = 400;
+        res.set_content("missing 'from' and/or 'to' query parameters", "text/plain");
+        return;
+    }
+
+    CassUuid sensor_id = parse_uuid(std::string(req.matches[1]));
+    int64_t from_ms    = parse_timestamp_ms(req.get_param_value("from"));
+    int64_t to_ms      = parse_timestamp_ms(req.get_param_value("to"));
+
+    const char* q =
+        "SELECT value FROM carepet.measurement"
+        " WHERE sensor_id = ? AND ts >= ? AND ts <= ?";
+    CassStatement* stmt = cass_statement_new(q, 3);
+    cass_statement_bind_uuid(stmt,  0, sensor_id);
+    cass_statement_bind_int64(stmt, 1, from_ms);
+    cass_statement_bind_int64(stmt, 2, to_ms);
+    const CassResult* result = execute_query(session, stmt);
+    cass_statement_free(stmt);
+
+    json arr = json::array();
+    CassIterator* it = cass_iterator_from_result(result);
+    while (cass_iterator_next(it)) {
+        cass_float_t v;
+        cass_value_get_float(cass_row_get_column(cass_iterator_get_row(it), 0), &v);
+        arr.push_back(static_cast<float>(v));
+    }
+    cass_iterator_free(it);
+    cass_result_free(result);
+    res.set_content(arr.dump(), "application/json");
+}
+
+// GET /api/sensor/{id}/values/day/{YYYY-MM-DD}  → array of 24 hourly avg floats
+static void handle_sensor_day(CassSession* session,
+                               const httplib::Request& req,
+                               httplib::Response& res) {
+    CassUuid sensor_id = parse_uuid(std::string(req.matches[1]));
+    std::string date_str = req.matches[2];
+    uint32_t date_days   = parse_date_days(date_str);
+
+    std::array<float, 24> avgs   = {};
+    std::array<int,   24> counts = {};
+
+    // Check for pre-computed hourly averages.
+    {
+        const char* q =
+            "SELECT hour, value FROM carepet.sensor_avg"
+            " WHERE sensor_id = ? AND date = ?";
+        CassStatement* stmt = cass_statement_new(q, 2);
+        cass_statement_bind_uuid(stmt,   0, sensor_id);
+        cass_statement_bind_uint32(stmt, 1, date_days);
+        const CassResult* result = execute_query(session, stmt);
+        cass_statement_free(stmt);
+
+        bool has_avg = cass_result_row_count(result) > 0;
+        if (has_avg) {
+            CassIterator* it = cass_iterator_from_result(result);
+            while (cass_iterator_next(it)) {
+                const CassRow* row = cass_iterator_get_row(it);
+                cass_int32_t hour;
+                cass_float_t value;
+                cass_value_get_int32(cass_row_get_column(row, 0), &hour);
+                cass_value_get_float(cass_row_get_column(row, 1), &value);
+                if (hour >= 0 && hour < 24) avgs[hour] = value;
+            }
+            cass_iterator_free(it);
+            cass_result_free(result);
+
+            json arr = json::array();
+            for (float v : avgs) arr.push_back(v);
+            res.set_content(arr.dump(), "application/json");
+            return;
+        }
+        cass_result_free(result);
+    }
+
+    // No pre-computed data: compute from raw measurements.
+    int64_t day_start_ms = static_cast<int64_t>(date_days) * 86400LL * 1000LL;
+    int64_t day_end_ms   = day_start_ms + 86400LL * 1000LL;
+
+    {
+        const char* q =
+            "SELECT ts, value FROM carepet.measurement"
+            " WHERE sensor_id = ? AND ts >= ? AND ts < ?";
+        CassStatement* stmt = cass_statement_new(q, 3);
+        cass_statement_bind_uuid(stmt,  0, sensor_id);
+        cass_statement_bind_int64(stmt, 1, day_start_ms);
+        cass_statement_bind_int64(stmt, 2, day_end_ms);
+        const CassResult* result = execute_query(session, stmt);
+        cass_statement_free(stmt);
+
+        CassIterator* it = cass_iterator_from_result(result);
+        while (cass_iterator_next(it)) {
+            const CassRow* row = cass_iterator_get_row(it);
+            cass_int64_t ts;
+            cass_float_t value;
+            cass_value_get_int64(cass_row_get_column(row, 0), &ts);
+            cass_value_get_float(cass_row_get_column(row, 1), &value);
+            int hour = static_cast<int>((ts - day_start_ms) / (3600LL * 1000LL));
+            if (hour >= 0 && hour < 24) {
+                avgs[hour] += value;
+                counts[hour]++;
+            }
+        }
+        cass_iterator_free(it);
+        cass_result_free(result);
+    }
+
+    // Compute averages and persist non-empty hours.
+    const char* iq =
+        "INSERT INTO carepet.sensor_avg (sensor_id, date, hour, value) VALUES (?, ?, ?, ?)";
+    for (int h = 0; h < 24; ++h) {
+        if (counts[h] > 0) {
+            avgs[h] /= static_cast<float>(counts[h]);
+            CassStatement* istmt = cass_statement_new(iq, 4);
+            cass_statement_bind_uuid(istmt,   0, sensor_id);
+            cass_statement_bind_uint32(istmt, 1, date_days);
+            cass_statement_bind_int32(istmt,  2, static_cast<cass_int32_t>(h));
+            cass_statement_bind_float(istmt,  3, avgs[h]);
+            execute_void(session, istmt);
+        }
+    }
+
+    json arr = json::array();
+    for (float v : avgs) arr.push_back(v);
+    res.set_content(arr.dump(), "application/json");
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+int main(int argc, char** argv) {
+    try {
+        Config cfg;
+        cfg.parse_args(argc, argv);
+
+        int port = 8000;
+        for (int i = 1; i + 1 < argc; ++i) {
+            std::string a = argv[i];
+            while (!a.empty() && a.front() == '-') a.erase(0, 1);
+            if (a == "port") port = std::stoi(argv[i + 1]);
+        }
+
+        std::cout << "Connecting to " << cfg.hosts << " ...\n";
+        Session session;
+        session.connect_keyspace(cfg, "carepet");
+        CassSession* raw = session.get();
+
+        httplib::Server svr;
+
+        // Register more-specific paths before less-specific ones.
+        svr.Get(R"(/api/owner/([^/]+)/pets)",
+            [raw](const httplib::Request& req, httplib::Response& res) {
+                try { handle_owner_pets(raw, req, res); }
+                catch (const std::exception& e) {
+                    res.status = 500;
+                    res.set_content(e.what(), "text/plain");
+                }
+            });
+
+        svr.Get(R"(/api/owner/([^/]+))",
+            [raw](const httplib::Request& req, httplib::Response& res) {
+                try { handle_owner(raw, req, res); }
+                catch (const std::exception& e) {
+                    res.status = 500;
+                    res.set_content(e.what(), "text/plain");
+                }
+            });
+
+        svr.Get(R"(/api/pet/([^/]+)/sensors)",
+            [raw](const httplib::Request& req, httplib::Response& res) {
+                try { handle_pet_sensors(raw, req, res); }
+                catch (const std::exception& e) {
+                    res.status = 500;
+                    res.set_content(e.what(), "text/plain");
+                }
+            });
+
+        svr.Get(R"(/api/sensor/([^/]+)/values/day/([^/]+))",
+            [raw](const httplib::Request& req, httplib::Response& res) {
+                try { handle_sensor_day(raw, req, res); }
+                catch (const std::exception& e) {
+                    res.status = 500;
+                    res.set_content(e.what(), "text/plain");
+                }
+            });
+
+        svr.Get(R"(/api/sensor/([^/]+)/values)",
+            [raw](const httplib::Request& req, httplib::Response& res) {
+                try { handle_sensor_values(raw, req, res); }
+                catch (const std::exception& e) {
+                    res.status = 500;
+                    res.set_content(e.what(), "text/plain");
+                }
+            });
+
+        std::cout << "Server listening on 0.0.0.0:" << port << "\n";
+        svr.listen("0.0.0.0", port);
+
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << "\n";
+        return 1;
+    }
+    return 0;
+}

--- a/cpp/db/keyspace.cql
+++ b/cpp/db/keyspace.cql
@@ -1,0 +1,3 @@
+CREATE KEYSPACE IF NOT EXISTS carepet
+    WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': '3' }
+    AND durable_writes = TRUE;

--- a/cpp/db/schema.cql
+++ b/cpp/db/schema.cql
@@ -1,0 +1,43 @@
+CREATE TABLE IF NOT EXISTS carepet.owner (
+    owner_id UUID,
+    address  TEXT,
+    name     TEXT,
+    PRIMARY KEY (owner_id)
+);
+
+CREATE TABLE IF NOT EXISTS carepet.pet (
+    owner_id UUID,
+    pet_id   UUID,
+    chip_id  TEXT,
+    species  TEXT,
+    breed    TEXT,
+    color    TEXT,
+    gender   TEXT,
+    age      INT,
+    weight   FLOAT,
+    address  TEXT,
+    name     TEXT,
+    PRIMARY KEY (owner_id, pet_id)
+);
+
+CREATE TABLE IF NOT EXISTS carepet.sensor (
+    pet_id    UUID,
+    sensor_id UUID,
+    type      TEXT,
+    PRIMARY KEY (pet_id, sensor_id)
+);
+
+CREATE TABLE IF NOT EXISTS carepet.measurement (
+    sensor_id UUID,
+    ts        TIMESTAMP,
+    value     FLOAT,
+    PRIMARY KEY (sensor_id, ts)
+) WITH compaction = { 'class': 'TimeWindowCompactionStrategy' };
+
+CREATE TABLE IF NOT EXISTS carepet.sensor_avg (
+    sensor_id UUID,
+    date      DATE,
+    hour      INT,
+    value     FLOAT,
+    PRIMARY KEY (sensor_id, date, hour)
+) WITH compaction = { 'class': 'TimeWindowCompactionStrategy' };

--- a/cpp/docker-compose.yml
+++ b/cpp/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+
+services:
+  cpp-app:
+    build: .
+    container_name: carepet-cpp
+    depends_on:
+      - carepet-scylla1
+    environment:
+      - SCYLLADB_HOSTS=carepet-scylla1
+    command: tail -F /dev/null
+
+  carepet-scylla1:
+    image: scylladb/scylla
+    container_name: carepet-scylla1
+    command: --smp 1
+    expose:
+      - '9042'
+
+  carepet-scylla2:
+    image: scylladb/scylla
+    container_name: carepet-scylla2
+    command: --smp 1 --seeds=carepet-scylla1
+    expose:
+      - '9042'
+
+  carepet-scylla3:
+    image: scylladb/scylla
+    container_name: carepet-scylla3
+    command: --smp 1 --seeds=carepet-scylla1
+    expose:
+      - '9042'

--- a/cpp/include/config.hpp
+++ b/cpp/include/config.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <cassandra.h>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+
+// ---------------------------------------------------------------------------
+// Config: connection parameters, populated from env vars then CLI args.
+// ---------------------------------------------------------------------------
+struct Config {
+    std::string hosts    = "127.0.0.1";
+    std::string username;
+    std::string password;
+    std::string dc;
+    int         port     = 9042;
+
+    // Populate from environment variables first, then override with argv.
+    // Accepted flags: --hosts / -hosts, --username, --password, --dc, --port
+    void parse_args(int argc, char** argv) {
+        if (const char* e = std::getenv("SCYLLADB_HOSTS"))    hosts    = e;
+        if (const char* e = std::getenv("SCYLLADB_USERNAME")) username = e;
+        if (const char* e = std::getenv("SCYLLADB_PASSWORD")) password = e;
+
+        for (int i = 1; i + 1 < argc; ++i) {
+            std::string a = argv[i];
+            while (!a.empty() && a.front() == '-') a.erase(0, 1);
+            if      (a == "hosts"    || a == "h") hosts    = argv[++i];
+            else if (a == "username")             username = argv[++i];
+            else if (a == "password")             password = argv[++i];
+            else if (a == "dc")                   dc       = argv[++i];
+            else if (a == "port")                 port     = std::stoi(argv[++i]);
+        }
+    }
+
+    bool is_cloud() const {
+        return hosts.find(".clusters.scylla.cloud") != std::string::npos;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Session: RAII wrapper around CassCluster + CassSession.
+// ---------------------------------------------------------------------------
+class Session {
+public:
+    Session() : cluster_(cass_cluster_new()), session_(cass_session_new()) {}
+
+    ~Session() {
+        if (session_) {
+            CassFuture* f = cass_session_close(session_);
+            cass_future_wait(f);
+            cass_future_free(f);
+            cass_session_free(session_);
+            session_ = nullptr;
+        }
+        if (cluster_) {
+            cass_cluster_free(cluster_);
+            cluster_ = nullptr;
+        }
+    }
+
+    Session(const Session&)            = delete;
+    Session& operator=(const Session&) = delete;
+
+    // Connect without selecting a keyspace.
+    void connect(const Config& cfg) {
+        apply_config(cfg);
+        check(cass_session_connect(session_, cluster_), "connect");
+    }
+
+    // Connect and select a keyspace.
+    void connect_keyspace(const Config& cfg, const std::string& ks) {
+        apply_config(cfg);
+        check(cass_session_connect_keyspace(session_, cluster_, ks.c_str()),
+              "connect_keyspace(" + ks + ")");
+    }
+
+    // Execute a DDL / DML statement that returns no rows.
+    void execute(const std::string& query) {
+        auto* stmt = cass_statement_new(query.c_str(), 0);
+        auto* f    = cass_session_execute(session_, stmt);
+        cass_statement_free(stmt);
+        check(f, query.substr(0, 60));
+    }
+
+    // Return the raw session pointer for use with the C driver API directly.
+    CassSession* get() { return session_; }
+
+private:
+    CassCluster* cluster_;
+    CassSession* session_;
+
+    void apply_config(const Config& cfg) {
+        cass_cluster_set_contact_points(cluster_, cfg.hosts.c_str());
+        cass_cluster_set_port(cluster_, cfg.port);
+        if (!cfg.username.empty())
+            cass_cluster_set_credentials(cluster_,
+                                         cfg.username.c_str(),
+                                         cfg.password.c_str());
+    }
+
+    // Wait for future, always free it, throw on error.
+    static void check(CassFuture* f, const std::string& ctx) {
+        cass_future_wait(f);
+        CassError rc = cass_future_error_code(f);
+        std::string err;
+        if (rc != CASS_OK) {
+            const char* msg; size_t len;
+            cass_future_error_message(f, &msg, &len);
+            err = std::string(msg, len);
+        }
+        cass_future_free(f);
+        if (rc != CASS_OK)
+            throw std::runtime_error(ctx + ": " + err);
+    }
+};

--- a/cpp/include/model.hpp
+++ b/cpp/include/model.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cassandra.h>
+#include <cstdint>
+#include <string>
+
+// Convert a CassUuid to its canonical "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" string.
+inline std::string uuid_to_string(CassUuid uuid) {
+    char buf[CASS_UUID_STRING_LENGTH];
+    cass_uuid_string(uuid, buf);
+    return {buf};
+}
+
+struct Owner {
+    CassUuid    owner_id{};
+    std::string address;
+    std::string name;
+};
+
+struct Pet {
+    CassUuid    owner_id{};
+    CassUuid    pet_id{};
+    std::string chip_id;
+    std::string species;
+    std::string breed;
+    std::string color;
+    std::string gender;
+    int32_t     age    = 0;
+    float       weight = 0.0f;
+    std::string address;
+    std::string name;
+};
+
+struct Sensor {
+    CassUuid    pet_id{};
+    CassUuid    sensor_id{};
+    std::string type; // "T" temperature, "P" pulse, "R" respiration, "L" location
+};
+
+struct Measurement {
+    CassUuid sensor_id{};
+    int64_t  ts    = 0;   // milliseconds since Unix epoch  (CQL TIMESTAMP)
+    float    value = 0.0f;
+};
+
+struct SensorAvg {
+    CassUuid sensor_id{};
+    uint32_t date  = 0;   // days since Unix epoch           (CQL DATE)
+    int32_t  hour  = 0;
+    float    value = 0.0f;
+};

--- a/cpp/include/rand_util.hpp
+++ b/cpp/include/rand_util.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "model.hpp"
+
+#include <cassandra.h>
+#include <random>
+#include <string>
+
+// ---------------------------------------------------------------------------
+// Thread-local Mersenne-Twister RNG.
+// ---------------------------------------------------------------------------
+inline std::mt19937& rng() {
+    static thread_local std::mt19937 g(std::random_device{}());
+    return g;
+}
+
+inline int rand_int(int lo, int hi) {
+    return std::uniform_int_distribution<int>(lo, hi)(rng());
+}
+
+inline float rand_float(float lo, float hi) {
+    return std::uniform_real_distribution<float>(lo, hi)(rng());
+}
+
+// Random lowercase-alpha string of given length.
+inline std::string rand_string(size_t len) {
+    static constexpr char kAlpha[] = "abcdefghijklmnopqrstuvwxyz";
+    std::uniform_int_distribution<size_t> d(0, 25);
+    std::string s(len, ' ');
+    for (auto& c : s) c = kAlpha[d(rng())];
+    return s;
+}
+
+inline Owner rand_owner(CassUuidGen* gen) {
+    Owner o;
+    cass_uuid_gen_random(gen, &o.owner_id);
+    o.name    = rand_string(8);
+    o.address = rand_string(10) + " st";
+    return o;
+}
+
+inline Pet rand_pet(CassUuidGen* gen, const Owner& owner) {
+    static constexpr const char* kSpecies[] = {"Dog", "Cat", "Rabbit", "Hamster"};
+    Pet p;
+    p.owner_id = owner.owner_id;
+    cass_uuid_gen_random(gen, &p.pet_id);
+    p.chip_id  = rand_string(16);
+    p.species  = kSpecies[rand_int(0, 3)];
+    p.breed    = rand_string(8);
+    p.color    = rand_string(6);
+    p.gender   = (rand_int(0, 1) == 0) ? "M" : "F";
+    p.age      = rand_int(1, 15);
+    p.weight   = rand_float(1.0f, 50.0f);
+    p.address  = owner.address;
+    p.name     = rand_string(6);
+    return p;
+}
+
+inline Sensor rand_sensor(CassUuidGen* gen, const Pet& pet) {
+    static constexpr const char* kTypes[] = {"T", "P", "R", "L"};
+    Sensor s;
+    s.pet_id = pet.pet_id;
+    cass_uuid_gen_random(gen, &s.sensor_id);
+    s.type = kTypes[rand_int(0, 3)];
+    return s;
+}
+
+// Generate a plausible sensor reading for the given sensor type:
+//   T = temperature (°F)   98–107
+//   P = pulse (bpm)        80–120
+//   R = respiration/min    33–37
+//   L = location/distance   0–10
+inline float rand_sensor_data(const Sensor& s) {
+    if (s.type == "T") return rand_float(98.0f, 107.0f);
+    if (s.type == "P") return rand_float(80.0f, 120.0f);
+    if (s.type == "R") return rand_float(33.0f,  37.0f);
+    return rand_float(0.0f, 10.0f); // "L"
+}

--- a/docs/build-with-cpp.md
+++ b/docs/build-with-cpp.md
@@ -1,0 +1,395 @@
+## Build an IoT App with C++
+
+### Architecture
+
+This section walks through and explains the code for the different commands.
+As explained in the Getting Started page, the project is structured as follows:
+
+- migrate (`/cmd/migrate/main.cpp`) – creates the `carepet` keyspace and tables
+- collar (`/cmd/sensor/main.cpp`) – generates pet health data and pushes it into the storage
+- web app (`/cmd/server/main.cpp`) – REST API service for tracking pets' health state
+
+### Migrate
+
+Start by creating a local ScyllaDB cluster consisting of 3 nodes:
+
+```
+$ docker-compose up -d
+```
+
+Docker-compose will spin up a ScyllaDB cluster consisting of 3 nodes
+(`carepet-scylla1`, `carepet-scylla2` and `carepet-scylla3`) along with
+the app container.  Wait for about two minutes and check the status of the
+cluster:
+
+```
+$ docker exec -it carepet-scylla1 nodetool status
+```
+
+Once all nodes show `UN` (Up Normal) status, run the migrate command.
+First, get the node IP address:
+
+```
+$ docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' carepet-scylla1
+```
+
+Then run the migrate binary:
+
+```
+$ NODE1=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' carepet-scylla1)
+$ docker exec carepet-cpp migrate --hosts $NODE1
+```
+
+The command executes `cmd/migrate/main.cpp`. It creates the keyspace and
+tables needed by the collar and server services.
+
+The `main` function in `cmd/migrate/main.cpp` connects first without a
+keyspace to create it, then reconnects with the keyspace to create all tables:
+
+```cpp
+// cmd/migrate/main.cpp
+
+int main(int argc, char** argv) {
+    Config cfg;
+    cfg.parse_args(argc, argv);
+
+    // Step 1: connect without a keyspace and create it.
+    {
+        Session s;
+        s.connect(cfg);
+        s.execute(KEYSPACE_DDL);
+    }
+
+    // Step 2: connect to the keyspace and create all tables.
+    {
+        Session s;
+        s.connect_keyspace(cfg, "carepet");
+        for (auto& [name, ddl] : TABLE_DDLS) {
+            s.execute(ddl);
+        }
+    }
+}
+```
+
+The `Session` class in `include/config.hpp` is a RAII wrapper around
+`CassCluster` and `CassSession` from the ScyllaDB C++ Driver.  It throws
+a `std::runtime_error` on any failure:
+
+```cpp
+// include/config.hpp
+
+void connect(const Config& cfg) {
+    apply_config(cfg);
+    check(cass_session_connect(session_, cluster_), "connect");
+}
+
+void connect_keyspace(const Config& cfg, const std::string& ks) {
+    apply_config(cfg);
+    check(cass_session_connect_keyspace(session_, cluster_, ks.c_str()),
+          "connect_keyspace(" + ks + ")");
+}
+```
+
+`apply_config` sets the contact points and credentials:
+
+```cpp
+void apply_config(const Config& cfg) {
+    cass_cluster_set_contact_points(cluster_, cfg.hosts.c_str());
+    cass_cluster_set_port(cluster_, cfg.port);
+    if (!cfg.username.empty())
+        cass_cluster_set_credentials(cluster_,
+                                     cfg.username.c_str(),
+                                     cfg.password.c_str());
+}
+```
+
+The keyspace DDL creates a keyspace with `NetworkTopologyStrategy` and
+replication factor 3:
+
+```sql
+CREATE KEYSPACE IF NOT EXISTS carepet
+    WITH replication = {'class':'NetworkTopologyStrategy','replication_factor':'3'}
+    AND durable_writes = TRUE
+```
+
+You can verify the database structure with:
+
+```
+$ docker exec -it carepet-scylla1 cqlsh
+cqlsh> USE carepet;
+cqlsh:carepet> DESCRIBE TABLES
+cqlsh:carepet> DESCRIBE TABLE pet
+```
+
+Expected output:
+
+```
+CREATE TABLE carepet.pet (
+    owner_id uuid,
+    pet_id uuid,
+    chip_id text,
+    species text,
+    breed text,
+    color text,
+    gender text,
+    address text,
+    age int,
+    name text,
+    weight float,
+    PRIMARY KEY (owner_id, pet_id)
+) WITH CLUSTERING ORDER BY (pet_id ASC)
+    ...
+```
+
+### Sensor
+
+The sensor service simulates the collar's activity and periodically saves
+measurements to the database.  Run it with:
+
+```
+$ NODE1=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' carepet-scylla1)
+$ docker exec -d carepet-cpp sensor --hosts $NODE1 --measure 5s --buffer-interval 1m
+```
+
+Arguments:
+
+- `--hosts` – contact point(s) for ScyllaDB
+- `--measure` – interval between sensor samples (e.g. `5s`, `1m`, `2h`)
+- `--buffer-interval` – how often buffered measurements are flushed to the DB
+
+The `main` function in `cmd/sensor/main.cpp` generates random owner, pet,
+and sensors, persists them, then enters the measurement loop:
+
+```cpp
+// cmd/sensor/main.cpp
+
+int main(int argc, char** argv) {
+    Config cfg;
+    cfg.parse_args(argc, argv);
+    // ... parse --measure and --buffer-interval ...
+
+    Session session;
+    session.connect_keyspace(cfg, "carepet");
+
+    CassUuidGen* uuid_gen = cass_uuid_gen_new();
+    Owner owner = rand_owner(uuid_gen);
+    Pet   pet   = rand_pet(uuid_gen, owner);
+
+    int num_sensors = rand_int(2, 4);
+    std::vector<Sensor> sensors;
+    for (int i = 0; i < num_sensors; ++i)
+        sensors.push_back(rand_sensor(uuid_gen, pet));
+
+    insert_owner(session.get(), owner);
+    insert_pet(session.get(), pet);
+    for (const auto& s : sensors)
+        insert_sensor(session.get(), s);
+
+    // Prepare the measurement INSERT once for efficiency.
+    const CassPrepared* prepared = /* prepare INSERT INTO measurement ... */;
+
+    std::vector<Measurement> buffer;
+    while (true) {
+        // Sample sensors every --measure interval.
+        for (const auto& s : sensors) {
+            Measurement m;
+            m.sensor_id = s.sensor_id;
+            m.ts        = now_ms();       // milliseconds since Unix epoch
+            m.value     = rand_sensor_data(s);
+            buffer.push_back(m);
+        }
+
+        // Flush to ScyllaDB every --buffer-interval.
+        flush_measurements(session.get(), prepared, buffer);
+        buffer.clear();
+    }
+}
+```
+
+The measurement `INSERT` is prepared once using `cass_session_prepare` to
+avoid repeated query-planning overhead:
+
+```cpp
+// cmd/sensor/main.cpp
+
+const char* mq =
+    "INSERT INTO carepet.measurement (sensor_id, ts, value) VALUES (?, ?, ?)";
+CassFuture* pf = cass_session_prepare(session.get(), mq);
+cass_future_wait(pf);
+const CassPrepared* prepared = cass_future_get_prepared(pf);
+cass_future_free(pf);
+```
+
+`rand_sensor_data` in `include/rand_util.hpp` generates realistic values
+for each sensor type:
+
+```cpp
+// include/rand_util.hpp
+
+inline float rand_sensor_data(const Sensor& s) {
+    if (s.type == "T") return rand_float(98.0f, 107.0f);  // temperature °F
+    if (s.type == "P") return rand_float(80.0f, 120.0f);  // pulse bpm
+    if (s.type == "R") return rand_float(33.0f,  37.0f);  // respiration /min
+    return rand_float(0.0f, 10.0f);                        // location distance
+}
+```
+
+Expected output:
+
+```
+New owner # 3d6c7e2a-f1c0-4b8e-9d1a-000000000001
+New pet    # a1b2c3d4-0000-0000-0000-000000000002
+  Sensor [T] # 11111111-0000-0000-0000-000000000001
+  Sensor [P] # 22222222-0000-0000-0000-000000000002
+Sensor loop started (measure every 5s, flush every 60s) ...
+[T] 11111111-... = 101.34
+[P] 22222222-... = 97.12
+...
+Flushing 24 measurement(s) to ScyllaDB ...
+```
+
+Write down the owner ID (the UUID after `New owner #`).
+
+### Server
+
+The server service is a REST API for querying pet health data.  It is built
+with [cpp-httplib](https://github.com/yhirose/cpp-httplib) and
+[nlohmann/json](https://github.com/nlohmann/json).
+
+Run it with:
+
+```
+$ NODE1=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' carepet-scylla1)
+$ docker exec -d carepet-cpp server --hosts $NODE1 --port 8000
+```
+
+The `main` function in `cmd/server/main.cpp` connects to the `carepet`
+keyspace and registers route handlers on a `httplib::Server`:
+
+```cpp
+// cmd/server/main.cpp
+
+int main(int argc, char** argv) {
+    Config cfg;
+    cfg.parse_args(argc, argv);
+    int port = 8000;
+    // ... parse --port ...
+
+    Session session;
+    session.connect_keyspace(cfg, "carepet");
+    CassSession* raw = session.get();
+
+    httplib::Server svr;
+
+    svr.Get(R"(/api/owner/([^/]+)/pets)",    [raw](...) { handle_owner_pets(raw, ...); });
+    svr.Get(R"(/api/owner/([^/]+))",         [raw](...) { handle_owner(raw, ...); });
+    svr.Get(R"(/api/pet/([^/]+)/sensors)",   [raw](...) { handle_pet_sensors(raw, ...); });
+    svr.Get(R"(/api/sensor/([^/]+)/values/day/([^/]+))",
+                                             [raw](...) { handle_sensor_day(raw, ...); });
+    svr.Get(R"(/api/sensor/([^/]+)/values)", [raw](...) { handle_sensor_values(raw, ...); });
+
+    svr.listen("0.0.0.0", port);
+}
+```
+
+The `handle_owner` function queries the `owner` table and returns JSON:
+
+```cpp
+// cmd/server/main.cpp
+
+static void handle_owner(CassSession* session,
+                          const httplib::Request& req,
+                          httplib::Response& res) {
+    CassUuid owner_id = parse_uuid(std::string(req.matches[1]));
+
+    const char* q =
+        "SELECT owner_id, address, name FROM carepet.owner WHERE owner_id = ?";
+    CassStatement* stmt = cass_statement_new(q, 1);
+    cass_statement_bind_uuid(stmt, 0, owner_id);
+    const CassResult* result = execute_query(session, stmt);
+    cass_statement_free(stmt);
+
+    if (cass_result_row_count(result) == 0) {
+        res.status = 404;
+        return;
+    }
+
+    const CassRow* row = cass_result_first_row(result);
+    Owner o;
+    cass_value_get_uuid(cass_row_get_column(row, 0), &o.owner_id);
+    o.address = col_str(row, 1);
+    o.name    = col_str(row, 2);
+    cass_result_free(result);
+
+    json j;
+    j["owner_id"] = uuid_to_string(o.owner_id);
+    j["address"]  = o.address;
+    j["name"]     = o.name;
+    res.set_content(j.dump(), "application/json");
+}
+```
+
+The `handle_sensor_day` handler implements a lazy-evaluated hourly average
+cache: it checks `sensor_avg` first; if no data is found it reads raw
+measurements, computes hourly averages, stores them in `sensor_avg`, and
+returns the 24-element array:
+
+```cpp
+// cmd/server/main.cpp
+
+static void handle_sensor_day(CassSession* session, ...) {
+    // 1. Check for pre-computed averages.
+    // SELECT hour, value FROM carepet.sensor_avg WHERE sensor_id = ? AND date = ?
+    if (has_avg) {
+        // return cached averages immediately
+        return;
+    }
+
+    // 2. Compute from raw measurements.
+    // SELECT ts, value FROM carepet.measurement WHERE sensor_id = ? AND ts >= ? AND ts < ?
+    for each measurement {
+        int hour = (ts - day_start_ms) / (3600 * 1000);
+        avgs[hour] += value;
+        counts[hour]++;
+    }
+
+    // 3. Store computed averages back into sensor_avg.
+    // INSERT INTO carepet.sensor_avg (sensor_id, date, hour, value) VALUES (?, ?, ?, ?)
+
+    // 4. Return the 24-element JSON array.
+}
+```
+
+### REST API Reference
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/owner/{uuid}` | Fetch owner by ID |
+| GET | `/api/owner/{uuid}/pets` | List pets for an owner |
+| GET | `/api/pet/{uuid}/sensors` | List sensors for a pet |
+| GET | `/api/sensor/{uuid}/values?from=T&to=T` | Raw readings in time range |
+| GET | `/api/sensor/{uuid}/values/day/{YYYY-MM-DD}` | 24 hourly averages |
+
+Use the owner ID printed by the sensor simulator to test the API:
+
+```bash
+# Get owner
+curl http://127.0.0.1:8000/api/owner/{owner_id}
+# → {"address":"...","name":"...","owner_id":"..."}
+
+# List pets
+curl http://127.0.0.1:8000/api/owner/{owner_id}/pets
+# → [{"age":6,"name":"...","owner_id":"...","pet_id":"...","weight":41.7,...}]
+
+# List sensors
+curl http://127.0.0.1:8000/api/pet/{pet_id}/sensors
+# → [{"pet_id":"...","sensor_id":"...","type":"T"},...]
+
+# Raw readings in a time range (ISO 8601 timestamps)
+curl "http://127.0.0.1:8000/api/sensor/{sensor_id}/values?from=2024-01-15T00:00:00Z&to=2024-01-15T23:59:59Z"
+# → [101.34,99.87,...]
+
+# Hourly averages for a day
+curl http://127.0.0.1:8000/api/sensor/{sensor_id}/values/day/2024-01-15
+# → [0.0,0.0,...,101.1,...,0.0]   (24 floats, one per hour)
+```


### PR DESCRIPTION
## Summary

This PR adds a complete C++17 example for the care-pet IoT demo, using the [ScyllaDB C++ driver](https://github.com/scylladb/cpp-driver).

### What's included

- **`cpp/`** — full implementation with three commands:
  - `migrate` — creates the `carepet` keyspace and all tables
  - `sensor` — collar simulator that streams sensor measurements to ScyllaDB
  - `server` — REST API (cpp-httplib) with 5 endpoints matching the Go/Rust examples
- **`docs/build-with-cpp.md`** — tutorial walkthrough modeled after the existing Go and Rust tutorials

### Implementation highlights

- RAII `Session` wrapper around the C ScyllaDB driver API
- Prepared statement reuse in the sensor simulator
- Lazy hourly-average computation + caching in `sensor_avg` table (same pattern as Go/Rust)
- CMake + FetchContent for cpp-httplib and nlohmann/json
- Multi-stage Dockerfile that builds the ScyllaDB C++ driver from source

### Testing

Tested against both a local 3-node Docker cluster and a ScyllaDB Cloud cluster:
- `migrate` ✅ — keyspace and 5 tables created
- `sensor` ✅ — measurements generated and flushed
- `server` ✅ — all 5 REST endpoints return correct JSON