### PR TITLE
fix: update keyspace creation to avoid scylladb syntax error. improve…

### DIFF
--- a/csharp/Resources/care-pet-keyspace.cql
+++ b/csharp/Resources/care-pet-keyspace.cql
@@ -1,1 +1,1 @@
-CREATE KEYSPACE IF NOT EXISTS carepet;
+CREATE KEYSPACE IF NOT EXISTS carepet WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 3};

--- a/csharp/Server/ModelController.cs
+++ b/csharp/Server/ModelController.cs
@@ -112,7 +112,7 @@ namespace CarePet.Server
             return Ok(data);
         }
 
-        public async System.Threading.Tasks.Task Aggregate(Guid id, DateTime day, List<float> data)
+        async System.Threading.Tasks.Task Aggregate(Guid id, DateTime day, List<float> data)
         {
             var nowUtc = DateTime.UtcNow;
 

--- a/csharp/docker-compose.yml
+++ b/csharp/docker-compose.yml
@@ -1,34 +1,47 @@
-version: '3.8'
+version: "3.8"
 
 services:
   carepet-scylla1:
     image: scylladb/scylla:5.2
     restart: always
-    command: --seeds=carepet-scylla1,carepet-scylla2 --smp 1 --memory 750M --overprovisioned 1 --api-address 0.0.0.0
+    # ONLY use scylla1 as the seed to prevent startup race conditions
+    command: --seeds=carepet-scylla1 --smp 1 --memory 750M --overprovisioned 1 --api-address 0.0.0.0 --developer-mode 1
     ports:
       - "9042:9042"
     volumes:
       - carepet-scylla1-data:/var/lib/scylla
     networks:
       - carepet-network
+    # This healthcheck tells Docker when scylla1 is officially ready
+    healthcheck:
+      test: ["CMD-SHELL", "nodetool status || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   carepet-scylla2:
     image: scylladb/scylla:5.2
     restart: always
-    command: --seeds=carepet-scylla1,carepet-scylla2 --smp 1 --memory 750M --overprovisioned 1 --api-address 0.0.0.0
+    command: --seeds=carepet-scylla1 --smp 1 --memory 750M --overprovisioned 1 --api-address 0.0.0.0 --developer-mode 1
     volumes:
       - carepet-scylla2-data:/var/lib/scylla
     networks:
       - carepet-network
+    depends_on:
+      carepet-scylla1:
+        condition: service_healthy
 
   carepet-scylla3:
     image: scylladb/scylla:5.2
     restart: always
-    command: --seeds=carepet-scylla1,carepet-scylla2 --smp 1 --memory 750M --overprovisioned 1 --api-address 0.0.0.0
+    command: --seeds=carepet-scylla1 --smp 1 --memory 750M --overprovisioned 1 --api-address 0.0.0.0 --developer-mode 1
     volumes:
       - carepet-scylla3-data:/var/lib/scylla
     networks:
       - carepet-network
+    depends_on:
+      carepet-scylla1:
+        condition: service_healthy
 
 volumes:
   carepet-scylla1-data:


### PR DESCRIPTION
this is to address issues with the csharp project  that prevent it from running successfully

- [x] update CREATE KEYSPACE to avoid syntax error in scylladb 

- [x] fix "no nodes present in the cluster" error 
accdg to google... 

> Your docker-compose.yaml file looks very clean, but there is a major catch with how ScyllaDB handles container names as seeds inside Docker.When you pass --seeds=carepet-scylla1,carepet-scylla2, ScyllaDB tries to resolve those names to IP addresses at the exact microsecond it boots up. Because Docker Compose starts containers at nearly the same time, carepet-scylla2 often doesn't have an IP address yet when carepet-scylla1 looks for it. This causes the network setup to fail silently, meaning the nodes never form a cluster. This is why nodetool tells you there are zero nodes present.

- [x] fix the error "fetch error Internal Server Error /swagger/v1/swagger.json" when trying to access swagger route